### PR TITLE
Added extensions to IDictionary<string, string> for ease of use in jobs

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationUtility.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationUtility.cs
@@ -8,15 +8,21 @@ namespace NuGet.Services.Configuration
 {
     public static class ConfigurationUtility
     {
+        /// <summary>
+        /// Converts a string into T.
+        /// </summary>
+        /// <typeparam name="T">Type that value will be converted into.</typeparam>
+        /// <param name="value">String to convert.</param>
+        /// <returns>Value converted into T.</returns>
+        /// <exception cref="NotSupportedException">Thrown when a conversion from string to T is impossible.</exception>
         public static T ConvertFromString<T>(string value)
         {
             var converter = TypeDescriptor.GetConverter(typeof(T));
             if (converter != null)
             {
-                // This will throw a NotSupportedException if no conversion is possible.
                 return (T)converter.ConvertFromString(value);
             }
-            // If there is no converter, no conversion is possible, so throw a NotSupportedException.
+
             throw new NotSupportedException("No converter exists from string to " + typeof(T).Name + "!");
         }
     }

--- a/src/NuGet.Services.Configuration/ConfigurationUtility.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationUtility.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+
+namespace NuGet.Services.Configuration
+{
+    public static class ConfigurationUtility
+    {
+        public static T ConvertFromString<T>(string value)
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(T));
+            if (converter != null)
+            {
+                // This will throw a NotSupportedException if no conversion is possible.
+                return (T)converter.ConvertFromString(value);
+            }
+            // If there is no converter, no conversion is possible, so throw a NotSupportedException.
+            throw new NotSupportedException("No converter exists from string to " + typeof(T).Name + "!");
+        }
+    }
+}

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -7,6 +7,13 @@ namespace NuGet.Services.Configuration
 {
     public static class DictionaryExtensions
     {
+        public static string TryGetValue(this IDictionary<string, string> dictionary, string key)
+        {
+            string value;
+            dictionary.TryGetValue(key, out value);
+            return value;
+        }
+
         public static T? TryGetValue<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             string valueString;

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.Configuration
     public static class DictionaryExtensions
     {
         /// <summary>
-        /// Gets the value associated with a key or null.
+        /// Gets the value associated with a key or null if there is no value associated with key.
         /// </summary>
         /// <param name="dictionary">Dictionary to get value from.</param>
         /// <param name="key">The key associated with the desired value.</param>
@@ -21,7 +21,7 @@ namespace NuGet.Services.Configuration
         }
 
         /// <summary>
-        /// Gets the value associated with a key and converts it into T or null.
+        /// Gets the value associated with a key and converts it into T or null if there is no value associated with key or the value could not be converted into T.
         /// </summary>
         /// <typeparam name="T">Type to convert value into.</typeparam>
         /// <param name="dictionary">Dictionary to get value from.</param>

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -7,14 +7,14 @@ namespace NuGet.Services.Configuration
 {
     public static class DictionaryExtensions
     {
-        public static string TryGetValue(this IDictionary<string, string> dictionary, string key)
+        public static string GetOrDefault(this IDictionary<string, string> dictionary, string key)
         {
             string value;
             dictionary.TryGetValue(key, out value);
             return value;
         }
 
-        public static T? TryGetValue<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        public static T? GetOrDefault<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             string valueString;
             if (!dictionary.TryGetValue(key, out valueString))
@@ -32,7 +32,7 @@ namespace NuGet.Services.Configuration
             }
         }
 
-        public static T Get<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        public static T GetOrThrow<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             return ConfigurationUtility.ConvertFromString<T>(dictionary[key]);
         }

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.Configuration
+{
+    public static class DictionaryExtensions
+    {
+        public static T? TryGetValue<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        {
+            string valueString;
+            if (!dictionary.TryGetValue(key, out valueString))
+            {
+                return null;
+            }
+
+            try
+            {
+                return ConfigurationUtility.ConvertFromString<T>(valueString);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static T Get<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        {
+            return ConfigurationUtility.ConvertFromString<T>(dictionary[key]);
+        }
+    }
+}

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -7,6 +7,12 @@ namespace NuGet.Services.Configuration
 {
     public static class DictionaryExtensions
     {
+        /// <summary>
+        /// Gets the value associated with a key or null.
+        /// </summary>
+        /// <param name="dictionary">Dictionary to get value from.</param>
+        /// <param name="key">The key associated with the desired value.</param>
+        /// <returns>The value associated with key in dictionary or null.</returns>
         public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
         {
             string value;
@@ -14,6 +20,13 @@ namespace NuGet.Services.Configuration
             return value;
         }
 
+        /// <summary>
+        /// Gets the value associated with a key and converts it into T or null.
+        /// </summary>
+        /// <typeparam name="T">Type to convert value into.</typeparam>
+        /// <param name="dictionary">Dictionary to get value from.</param>
+        /// <param name="key">The key associated with the desired value.</param>
+        /// <returns>The value associated with key converted into T or null.</returns>
         public static T? GetOrNull<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             string valueString;
@@ -32,6 +45,15 @@ namespace NuGet.Services.Configuration
             }
         }
 
+        /// <summary>
+        /// Gets the value associated with a key and converts it into T or throws.
+        /// </summary>
+        /// <typeparam name="T">Type to convert value into.</typeparam>
+        /// <param name="dictionary">Dictionary to get value from.</param>
+        /// <param name="key">The key associated with the desired value.</param>
+        /// <returns>The value associated with key converted into T.</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when there is no value associated with key in the dictionary.</exception>
+        /// <exception cref="NotSupportedException">Thrown when a conversion from string to T is impossible.</exception>
         public static T GetOrThrow<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             return ConfigurationUtility.ConvertFromString<T>(dictionary[key]);

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -7,14 +7,14 @@ namespace NuGet.Services.Configuration
 {
     public static class DictionaryExtensions
     {
-        public static string GetOrDefault(this IDictionary<string, string> dictionary, string key)
+        public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
         {
             string value;
             dictionary.TryGetValue(key, out value);
             return value;
         }
 
-        public static T? GetOrDefault<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        public static T? GetOrNull<T>(this IDictionary<string, string> dictionary, string key) where T : struct
         {
             string valueString;
             if (!dictionary.TryGetValue(key, out valueString))

--- a/tests/NuGet.Services.Configuration.Tests/ConfigurationUtilityFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/ConfigurationUtilityFacts.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.Services.Configuration.Tests
+{
+    public class ConfigurationUtilityFacts
+    {
+        public static IEnumerable<object[]> ValueData => new[]
+        {
+            new object[] {true},
+            new object[] {false},
+            new object[] {-1},
+            new object[] {1259},
+            new object[] {DateTime.MinValue},
+            new object[] {DateTime.MinValue.AddYears(100).AddDays(50).AddHours(5).AddSeconds(62)}
+        };
+
+        [Theory]
+        [MemberData(nameof(ValueData))]
+        public void ConvertFromStringConvertsToType<T>(T value)
+        {
+            // Arrange
+            var valueString = value.ToString();
+
+            // Act
+            var result = ConfigurationUtility.ConvertFromString<T>(valueString);
+
+            // Assert
+            Assert.Equal(value, result);
+        }
+
+        private class NoConversionFromStringToThisClass
+        {
+        }
+
+        [Fact]
+        public void ConvertFromStringThrowsNotSupportedException()
+        {
+            // Arrange
+            const string key = "convert me!";
+
+            // Assert
+            Assert.Throws<NotSupportedException>(
+                () => ConfigurationUtility.ConvertFromString<NoConversionFromStringToThisClass>(key));
+        }
+    }
+}

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -19,6 +19,27 @@ namespace NuGet.Services.Configuration.Tests
             new object[] {DateTime.MinValue.AddYears(100).AddDays(50).AddHours(5).AddSeconds(62)} 
         };
 
+        [Fact]
+        public void TryGetValueStringReturnsAndDoesNotThrow()
+        {
+            // Arrange
+            const string key = "key";
+            const string value = "value";
+            const string notKey = "notAKey";
+            IDictionary<string, string> dictionary = new Dictionary<string, string>
+            {
+                {key, value}
+            };
+
+            // Act
+            var valueFromDictionary = dictionary.TryGetValue(key);
+            var notFoundFromDictionary = dictionary.TryGetValue(notKey);
+
+            // Assert
+            Assert.Equal(value, valueFromDictionary);
+            Assert.Equal(default(string), notFoundFromDictionary);
+        }
+
         [Theory]
         [MemberData(nameof(ValueData))]
         public void TryGetValueConvertsAndDoesNotThrow<T>(T value) where T : struct

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.Configuration.Tests
         };
 
         [Fact]
-        public void GetOrDefaultStringReturnsAndDoesNotThrow()
+        public void GetOrNullStringReturnsAndDoesNotThrow()
         {
             // Arrange
             const string key = "key";
@@ -32,8 +32,8 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.GetOrDefault(key);
-            var notFoundFromDictionary = dictionary.GetOrDefault(notKey);
+            var valueFromDictionary = dictionary.GetOrNull(key);
+            var notFoundFromDictionary = dictionary.GetOrNull(notKey);
 
             // Assert
             Assert.Equal(value, valueFromDictionary);
@@ -42,7 +42,7 @@ namespace NuGet.Services.Configuration.Tests
 
         [Theory]
         [MemberData(nameof(ValueData))]
-        public void GetOrDefaultConvertsAndDoesNotThrow<T>(T value) where T : struct
+        public void GetOrNullConvertsAndDoesNotThrow<T>(T value) where T : struct
         {
             // Arrange
             const string key = "key";
@@ -53,8 +53,8 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.GetOrDefault<T>(key);
-            var notFoundFromDictionary = dictionary.GetOrDefault<T>(notKey);
+            var valueFromDictionary = dictionary.GetOrNull<T>(key);
+            var notFoundFromDictionary = dictionary.GetOrNull<T>(notKey);
 
             // Assert
             Assert.True(valueFromDictionary.HasValue);

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.Services.Configuration.Tests
+{
+    public class DictionaryExtensionsFacts
+    {
+        public static IEnumerable<object[]> ValueData => new[]
+        {
+            new object[] {true},
+            new object[] {false},
+            new object[] {-1},
+            new object[] {1259},    
+            new object[] {DateTime.MinValue},
+            new object[] {DateTime.MinValue.AddYears(100).AddDays(50).AddHours(5).AddSeconds(62)} 
+        };
+
+        [Theory]
+        [MemberData(nameof(ValueData))]
+        public void TryGetValueConvertsAndDoesNotThrow<T>(T value) where T : struct
+        {
+            // Arrange
+            const string key = "key";
+            const string notKey = "notAKey";
+            IDictionary<string, string> dictionary = new Dictionary<string, string>
+            {
+                {key, value.ToString()}
+            };
+
+            // Act
+            var valueFromDictionary = dictionary.TryGetValue<T>(key);
+            var notFoundFromDictionary = dictionary.TryGetValue<T>(notKey);
+
+            // Assert
+            Assert.True(valueFromDictionary.HasValue);
+            Assert.Equal(value, valueFromDictionary.Value);
+            Assert.False(notFoundFromDictionary.HasValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValueData))]
+        public void GetConvertsValueAndThrows<T>(T value) where T : struct
+        {
+            // Arrange
+            const string key = "key";
+            const string notKey = "notAKey";
+            IDictionary<string, string> dictionary = new Dictionary<string, string>
+            {
+                {key, value.ToString()}
+            };
+
+            // Act
+            var valueFromDictionary = dictionary.Get<T>(key);
+
+            // Assert
+            Assert.Equal(value, valueFromDictionary);
+            Assert.Throws<KeyNotFoundException>(() => dictionary.Get<T>(notKey));
+        }
+    }
+}

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -19,6 +19,10 @@ namespace NuGet.Services.Configuration.Tests
             new object[] {DateTime.MinValue.AddYears(100).AddDays(50).AddHours(5).AddSeconds(62)} 
         };
 
+        private struct NoConversionFromStringToThisStruct
+        {
+        }
+
         [Fact]
         public void GetOrNullStringReturnsAndDoesNotThrow()
         {
@@ -55,11 +59,13 @@ namespace NuGet.Services.Configuration.Tests
             // Act
             var valueFromDictionary = dictionary.GetOrNull<T>(key);
             var notFoundFromDictionary = dictionary.GetOrNull<T>(notKey);
+            var notSupportedFromDictionary = dictionary.GetOrNull<NoConversionFromStringToThisStruct>(key);
 
             // Assert
             Assert.True(valueFromDictionary.HasValue);
             Assert.Equal(value, valueFromDictionary.Value);
             Assert.False(notFoundFromDictionary.HasValue);
+            Assert.False(notSupportedFromDictionary.HasValue);
         }
 
         [Theory]
@@ -80,6 +86,7 @@ namespace NuGet.Services.Configuration.Tests
             // Assert
             Assert.Equal(value, valueFromDictionary);
             Assert.Throws<KeyNotFoundException>(() => dictionary.GetOrThrow<T>(notKey));
+            Assert.Throws<NotSupportedException>(() => dictionary.GetOrThrow<NoConversionFromStringToThisStruct>(key));
         }
     }
 }

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.Configuration.Tests
         };
 
         [Fact]
-        public void TryGetValueStringReturnsAndDoesNotThrow()
+        public void GetOrDefaultStringReturnsAndDoesNotThrow()
         {
             // Arrange
             const string key = "key";
@@ -32,8 +32,8 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.TryGetValue(key);
-            var notFoundFromDictionary = dictionary.TryGetValue(notKey);
+            var valueFromDictionary = dictionary.GetOrDefault(key);
+            var notFoundFromDictionary = dictionary.GetOrDefault(notKey);
 
             // Assert
             Assert.Equal(value, valueFromDictionary);
@@ -42,7 +42,7 @@ namespace NuGet.Services.Configuration.Tests
 
         [Theory]
         [MemberData(nameof(ValueData))]
-        public void TryGetValueConvertsAndDoesNotThrow<T>(T value) where T : struct
+        public void GetOrDefaultConvertsAndDoesNotThrow<T>(T value) where T : struct
         {
             // Arrange
             const string key = "key";
@@ -53,8 +53,8 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.TryGetValue<T>(key);
-            var notFoundFromDictionary = dictionary.TryGetValue<T>(notKey);
+            var valueFromDictionary = dictionary.GetOrDefault<T>(key);
+            var notFoundFromDictionary = dictionary.GetOrDefault<T>(notKey);
 
             // Assert
             Assert.True(valueFromDictionary.HasValue);
@@ -64,7 +64,7 @@ namespace NuGet.Services.Configuration.Tests
 
         [Theory]
         [MemberData(nameof(ValueData))]
-        public void GetConvertsValueAndThrows<T>(T value) where T : struct
+        public void GetOrThrowConvertsValueAndThrows<T>(T value) where T : struct
         {
             // Arrange
             const string key = "key";
@@ -75,11 +75,11 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.Get<T>(key);
+            var valueFromDictionary = dictionary.GetOrThrow<T>(key);
 
             // Assert
             Assert.Equal(value, valueFromDictionary);
-            Assert.Throws<KeyNotFoundException>(() => dictionary.Get<T>(notKey));
+            Assert.Throws<KeyNotFoundException>(() => dictionary.GetOrThrow<T>(notKey));
         }
     }
 }


### PR DESCRIPTION
Currently, our jobs in `NuGet.Jobs` and our jobs in `NuGet.Services.Metadata` both use their own "TryGet" infrastructure. This manifests as [`JobConfigurationManager`](https://github.com/NuGet/NuGet.Jobs/blob/master/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs) in `NuGet.Jobs` and [`CommandHelpers`](https://github.com/NuGet/NuGet.Services.Metadata/blob/master/src/Ng/CommandHelpers.cs) in `NuGet.Services.Metadata`.

I have added some extensions to `IDictionary<string, string>` to `NuGet.Services.Configuration` to consolidate the logic in a single place.

(`ConvertFromString` will also be using in the `SecretService` class for secret rotation and so it is in its own utility class.)