### PR TITLE
Dictionary<string, string> Extensions 2.0

### DIFF
--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Services.Configuration
@@ -8,31 +9,18 @@ namespace NuGet.Services.Configuration
     public static class DictionaryExtensions
     {
         /// <summary>
-        /// Gets the value associated with a key or null if there is no value associated with key.
-        /// </summary>
-        /// <param name="dictionary">Dictionary to get value from.</param>
-        /// <param name="key">The key associated with the desired value.</param>
-        /// <returns>The value associated with key in dictionary or null.</returns>
-        public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
-        {
-            string value;
-            dictionary.TryGetValue(key, out value);
-            return value;
-        }
-
-        /// <summary>
         /// Gets the value associated with a key and converts it into T or null if there is no value associated with key or the value could not be converted into T.
         /// </summary>
         /// <typeparam name="T">Type to convert value into.</typeparam>
         /// <param name="dictionary">Dictionary to get value from.</param>
         /// <param name="key">The key associated with the desired value.</param>
         /// <returns>The value associated with key converted into T or null.</returns>
-        public static T? GetOrNull<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        public static T GetOrDefault<T>(this IDictionary<string, string> dictionary, string key, T defaultValue = default(T))
         {
             string valueString;
             if (!dictionary.TryGetValue(key, out valueString))
             {
-                return null;
+                return defaultValue;
             }
 
             try
@@ -41,7 +29,7 @@ namespace NuGet.Services.Configuration
             }
             catch
             {
-                return null;
+                return defaultValue;
             }
         }
 
@@ -54,7 +42,7 @@ namespace NuGet.Services.Configuration
         /// <returns>The value associated with key converted into T.</returns>
         /// <exception cref="KeyNotFoundException">Thrown when there is no value associated with key in the dictionary.</exception>
         /// <exception cref="NotSupportedException">Thrown when a conversion from string to T is impossible.</exception>
-        public static T GetOrThrow<T>(this IDictionary<string, string> dictionary, string key) where T : struct
+        public static T GetOrThrow<T>(this IDictionary<string, string> dictionary, string key)
         {
             return ConfigurationUtility.ConvertFromString<T>(dictionary[key]);
         }

--- a/src/NuGet.Services.Configuration/DictionaryExtensions.cs
+++ b/src/NuGet.Services.Configuration/DictionaryExtensions.cs
@@ -9,28 +9,18 @@ namespace NuGet.Services.Configuration
     public static class DictionaryExtensions
     {
         /// <summary>
-        /// Gets the value associated with a key and converts it into T or null if there is no value associated with key or the value could not be converted into T.
+        /// Gets the value associated with a key and converts it into T or returns a specified default.
         /// </summary>
         /// <typeparam name="T">Type to convert value into.</typeparam>
         /// <param name="dictionary">Dictionary to get value from.</param>
         /// <param name="key">The key associated with the desired value.</param>
+        /// <param name="defaultValue">The default value to return if the key cannot be found.</param>
         /// <returns>The value associated with key converted into T or null.</returns>
+        /// <exception cref="NotSupportedException">Thrown when a conversion from string to T is impossible.</exception>
         public static T GetOrDefault<T>(this IDictionary<string, string> dictionary, string key, T defaultValue = default(T))
         {
             string valueString;
-            if (!dictionary.TryGetValue(key, out valueString))
-            {
-                return defaultValue;
-            }
-
-            try
-            {
-                return ConfigurationUtility.ConvertFromString<T>(valueString);
-            }
-            catch
-            {
-                return defaultValue;
-            }
+            return dictionary.TryGetValue(key, out valueString) ? ConfigurationUtility.ConvertFromString<T>(valueString) : defaultValue;
         }
 
         /// <summary>

--- a/tests/NuGet.Services.Configuration.Tests/ConfigurationUtilityFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/ConfigurationUtilityFacts.cs
@@ -13,6 +13,8 @@ namespace NuGet.Services.Configuration.Tests
         {
             new object[] {true},
             new object[] {false},
+            new object[] {"hello"},
+            new object[] {"123456789"},
             new object[] {-1},
             new object[] {1259},
             new object[] {DateTime.MinValue},

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -13,6 +13,8 @@ namespace NuGet.Services.Configuration.Tests
         {
             new object[] {true},
             new object[] {false},
+            new object[] {"hello"},
+            new object[] {"123456789"},
             new object[] {-1},
             new object[] {1259},    
             new object[] {DateTime.MinValue},
@@ -23,30 +25,9 @@ namespace NuGet.Services.Configuration.Tests
         {
         }
 
-        [Fact]
-        public void GetOrNullStringReturnsAndDoesNotThrow()
-        {
-            // Arrange
-            const string key = "key";
-            const string value = "value";
-            const string notKey = "notAKey";
-            IDictionary<string, string> dictionary = new Dictionary<string, string>
-            {
-                {key, value}
-            };
-
-            // Act
-            var valueFromDictionary = dictionary.GetOrNull(key);
-            var notFoundFromDictionary = dictionary.GetOrNull(notKey);
-
-            // Assert
-            Assert.Equal(value, valueFromDictionary);
-            Assert.Equal(default(string), notFoundFromDictionary);
-        }
-
         [Theory]
         [MemberData(nameof(ValueData))]
-        public void GetOrNullConvertsAndDoesNotThrow<T>(T value) where T : struct
+        public void GetOrNullConvertsAndDoesNotThrow<T>(T value)
         {
             // Arrange
             const string key = "key";
@@ -57,20 +38,19 @@ namespace NuGet.Services.Configuration.Tests
             };
 
             // Act
-            var valueFromDictionary = dictionary.GetOrNull<T>(key);
-            var notFoundFromDictionary = dictionary.GetOrNull<T>(notKey);
-            var notSupportedFromDictionary = dictionary.GetOrNull<NoConversionFromStringToThisStruct>(key);
+            var valueFromDictionary = dictionary.GetOrDefault<T>(key);
+            var notFoundFromDictionary = dictionary.GetOrDefault<T>(notKey);
+            var notSupportedFromDictionary = dictionary.GetOrDefault<NoConversionFromStringToThisStruct>(key);
 
             // Assert
-            Assert.True(valueFromDictionary.HasValue);
-            Assert.Equal(value, valueFromDictionary.Value);
-            Assert.False(notFoundFromDictionary.HasValue);
-            Assert.False(notSupportedFromDictionary.HasValue);
+            Assert.Equal(value, valueFromDictionary);
+            Assert.Equal(default(T), notFoundFromDictionary);
+            Assert.Equal(default(NoConversionFromStringToThisStruct), notSupportedFromDictionary);
         }
 
         [Theory]
         [MemberData(nameof(ValueData))]
-        public void GetOrThrowConvertsValueAndThrows<T>(T value) where T : struct
+        public void GetOrThrowConvertsValueAndThrows<T>(T value)
         {
             // Arrange
             const string key = "key";

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryExtensionsFacts.cs
@@ -60,22 +60,25 @@ namespace NuGet.Services.Configuration.Tests
         {
             // Arrange
             const string key = "key";
+            const string notKey = "notAKey";
             IDictionary<string, string> dictionary = new Dictionary<string, string>
             {
                 {key, "i am a string"}
             };
 
             // Act
-            var notSupportedFromDictionary = dictionary.GetOrDefault<NoConversionFromStringToThisClass>(key);
+            var notFoundFromDictionary = dictionary.GetOrDefault<NoConversionFromStringToThisClass>(notKey);
 
             // default(NoConversionFromStringToThisClass) has value = false because default(bool) is false
             // Therefore, create a NoConversionFromStringToThisClass with a true value so it is different than the default.
             var defaultNoConversion = new NoConversionFromStringToThisClass(true);
-            var notSupportedFromDictionaryWithDefault = dictionary.GetOrDefault(key, defaultNoConversion);
+            var notFoundFromDictionaryWithDefault = dictionary.GetOrDefault(notKey, defaultNoConversion);
 
             // Assert
-            Assert.Equal(default(NoConversionFromStringToThisClass), notSupportedFromDictionary);
-            Assert.Equal(defaultNoConversion, notSupportedFromDictionaryWithDefault);
+            Assert.Throws<NotSupportedException>(() => dictionary.GetOrDefault<NoConversionFromStringToThisClass>(key));
+            Assert.Equal(default(NoConversionFromStringToThisClass), notFoundFromDictionary);
+            Assert.Equal(defaultNoConversion, notFoundFromDictionaryWithDefault);
+            // Safety check to prevent the test from passing if defaultNoConversion is equal to default(NoConversionFromStringToThisClass)
             Assert.NotEqual(defaultNoConversion, default(NoConversionFromStringToThisClass));
         }
 


### PR DESCRIPTION
Rename `GetOrNull` to `GetOrDefault`.
Remove constraint on `GetOrThrow`.
Modified test cases appropriately.