### PR TITLE
improved the exception message if the certificate is not found

### DIFF
--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -72,9 +72,8 @@ namespace NuGet.Services.KeyVault
                 var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
                 if (col.Count == 0)
                 {
-                    var validationRequiredString = validationRequired ? "required" : "not required";
                     throw new ArgumentException(
-                        $"Certificate with thumbprint {thumbprint} and validation {validationRequiredString} was not found in store {storeLocation} {storeName}.");
+                        $"Certificate with thumbprint {thumbprint} and validation {(validationRequired ? "required" : "not required")} was not found in store {storeLocation} {storeName}.");
                 }
 
                 return col[0];

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -72,7 +72,9 @@ namespace NuGet.Services.KeyVault
                 var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
                 if (col.Count == 0)
                 {
-                    throw new ArgumentException($"Certificate with thumbprint {thumbprint} was not found in store {storeLocation} {storeName} ");
+                    var validationRequiredString = validationRequired ? "required" : "not required";
+                    throw new ArgumentException(
+                        $"Certificate with thumbprint {thumbprint} and validation {validationRequiredString} was not found in store {storeLocation} {storeName}.");
                 }
 
                 return col[0];


### PR DESCRIPTION
Spent far too long today debugging a stupid issue where the validation was incorrect but I thought it was a problem with the thumbprint. I think adding it to the exception message will improve debugging in the future.