### PR TITLE
ISecretWriter

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationFactory.cs
@@ -124,20 +124,22 @@ namespace NuGet.Services.Configuration
                 var defaultValueAttribute = property.Attributes.OfType<DefaultValueAttribute>().FirstOrDefault();
                 if (defaultValueAttribute != null)
                 {
+                    TP defaultValue;
                     try
                     {
                         // Use the default value specified by the DefaultValueAttribute if it can be converted into the type of the property.
-                        var defaultValue =
+                        defaultValue =
                             (TP)
                             (defaultValueAttribute.Value.GetType() == property.PropertyType
                                 ? defaultValueAttribute.Value
                                 : property.Converter.ConvertFrom(defaultValueAttribute.Value));
-                        value = await _configProvider.GetOrDefaultAsync(configKey, defaultValue);
                     }
                     catch (Exception)
                     {
                         throw new ArgumentException($"Default value for {configKey} specified by {nameof(DefaultValueAttribute)} is malformed ({defaultValueAttribute.Value ?? "null"})!");
                     }
+
+                    value = await _configProvider.GetOrDefaultAsync(configKey, defaultValue);
                 }
                 else
                 {

--- a/src/NuGet.Services.KeyVault/EmptySecretReader.cs
+++ b/src/NuGet.Services.KeyVault/EmptySecretReader.cs
@@ -7,9 +7,14 @@ namespace NuGet.Services.KeyVault
 {
     public class EmptySecretReader : ISecretReader
     {
-        public Task<string> GetSecretAsync(string secretName)
+        public Task<Secret> GetSecretAsync(Secret secret)
         {
-            return Task.FromResult(secretName);
+            return Task.FromResult(secret);
+        }
+
+        public Task<Secret> GetSecretAsync(string secretName)
+        {
+            return Task.FromResult(new Secret(secretName, secretName));
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/ISecretReader.cs
+++ b/src/NuGet.Services.KeyVault/ISecretReader.cs
@@ -7,6 +7,18 @@ namespace NuGet.Services.KeyVault
 {
     public interface ISecretReader
     {
-        Task<string> GetSecretAsync(string secretName);
+        /// <summary>
+        /// Gets a secret.
+        /// </summary>
+        /// <param name="secret">A secret with the same name as the secret to acquire.</param>
+        /// <returns>A secret specified by <paramref name="secret"/>.</returns>
+        Task<Secret> GetSecretAsync(Secret secret);
+
+        /// <summary>
+        /// Gets a secret.
+        /// </summary>
+        /// <param name="secretName">The name of the secret to acquire.</param>
+        /// <returns>A secret with the name specified by <paramref name="secretName"/>.</returns>
+        Task<Secret> GetSecretAsync(string secretName);
     }
 }

--- a/src/NuGet.Services.KeyVault/ISecretWriter.cs
+++ b/src/NuGet.Services.KeyVault/ISecretWriter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault
 {
-    public interface ISecretWriter : ISecretReader
+    public interface ISecretWriter
     {
         /// <summary>
         /// Sets the value of a secret.

--- a/src/NuGet.Services.KeyVault/ISecretWriter.cs
+++ b/src/NuGet.Services.KeyVault/ISecretWriter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    public interface ISecretWriter : ISecretReader
+    {
+        /// <summary>
+        /// Sets the value of a secret.
+        /// If a secret with the same name as <paramref name="secret"/> already exists, it will be overwritten.
+        /// </summary>
+        /// <param name="secret">A secret to set.</param>
+        /// <returns>The secret that has been set.</returns>
+        Task<Secret> SetSecretAsync(Secret secret);
+
+        /// <summary>
+        /// Sets the value of a secret.
+        /// If a secret with the same name as <paramref name="secretName"/> already exists, it will be overwritten.
+        /// </summary>
+        /// <param name="secretName">The name of the secret to set.</param>
+        /// <param name="value">The value of the secret to set.</param>
+        /// <param name="tags">The tags of the secret to set.</param>
+        /// <returns>The secret that has been set.</returns>
+        Task<Secret> SetSecretAsync(string secretName, string value, Dictionary<string, string> tags = null);
+
+        /// <summary>
+        /// Deletes a secret.
+        /// </summary>
+        /// <param name="secret">A secret with the same name as the secret to delete.</param>
+        /// <returns>The deleted secret.</returns>
+        Task<Secret> DeleteSecretAsync(Secret secret);
+
+        /// <summary>
+        /// Deletes a secret.
+        /// </summary>
+        /// <param name="secretName">The name of the secret to delete.</param>
+        /// <returns>The deleted secret.</returns>
+        Task<Secret> DeleteSecretAsync(string secretName);
+    }
+}

--- a/src/NuGet.Services.KeyVault/ISecretWriterFactory.cs
+++ b/src/NuGet.Services.KeyVault/ISecretWriterFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.KeyVault
+{
+    public interface ISecretWriterFactory
+    {
+        ISecretWriter CreateSecretWriter();
+    }
+}

--- a/src/NuGet.Services.KeyVault/KeyVaultSecret.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultSecret.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.KeyVault
+{
+    public class KeyVaultSecret : Secret
+    {
+        public KeyVaultSecret(Microsoft.Azure.KeyVault.Secret secret)
+            : base(secret.SecretIdentifier.Name, secret.Value, secret.Tags)
+        {
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/KeyVaultWriter.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultWriter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    public class KeyVaultWriter : KeyVaultReader, ISecretWriter
+    {
+        public KeyVaultWriter(KeyVaultConfiguration configuration) : 
+            base(configuration)
+        {
+        }
+
+        public Task<Secret> SetSecretAsync(Secret secret)
+        {
+            return SetSecretAsync(secret.Name, secret.Value, secret.Tags);
+        }
+        
+        public async Task<Secret> SetSecretAsync(string secretName, string value, Dictionary<string, string> tags = null)
+        {
+            return new KeyVaultSecret(await KeyVaultClient.Value.SetSecretAsync(Vault, secretName, value, tags));
+        }
+
+        public Task<Secret> DeleteSecretAsync(Secret secret)
+        {
+            return DeleteSecretAsync(secret.Name);
+        }
+
+        public async Task<Secret> DeleteSecretAsync(string secretName)
+        {
+            return new KeyVaultSecret(await KeyVaultClient.Value.DeleteSecretAsync(Vault, secretName));
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -97,8 +97,13 @@
     <Compile Include="EmptySecretReader.cs" />
     <Compile Include="ISecretInjector.cs" />
     <Compile Include="ISecretReader.cs" />
+    <Compile Include="ISecretWriter.cs" />
+    <Compile Include="ISecretWriterFactory.cs" />
     <Compile Include="KeyVaultConfiguration.cs" />
     <Compile Include="KeyVaultReader.cs" />
+    <Compile Include="KeyVaultSecret.cs" />
+    <Compile Include="Secret.cs" />
+    <Compile Include="KeyVaultWriter.cs" />
     <Compile Include="SecretInjector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/NuGet.Services.KeyVault/Secret.cs
+++ b/src/NuGet.Services.KeyVault/Secret.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.KeyVault
+{
+    public class Secret
+    {
+        public Secret(string name, string value, Dictionary<string, string> tags = null)
+        {
+            Name = name;
+            Value = value;
+            Tags = tags;
+        }
+
+        /// <summary>
+        /// A unique identifier under which the secret can be accessed.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The value of the secret.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// A set of key-value pairs that provide additional information about the secret.
+        /// </summary>
+        public Dictionary<string, string> Tags { get; set; }
+    }
+}

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -46,8 +46,8 @@ namespace NuGet.Services.KeyVault
 
             foreach (var secretName in secretNames)
             {
-                var secretValue = await _secretReader.GetSecretAsync(secretName);
-                output.Replace($"{_frame}{secretName}{_frame}", secretValue);
+                var secret = await _secretReader.GetSecretAsync(secretName);
+                output.Replace($"{_frame}{secretName}{_frame}", secret.Value);
             }
 
             return output.ToString();

--- a/tests/NuGet.Services.Configuration.Tests/DictionaryConfigurationProvider.cs
+++ b/tests/NuGet.Services.Configuration.Tests/DictionaryConfigurationProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
@@ -55,7 +55,7 @@ namespace NuGet.Services.KeyVault.Tests
         public KeyVaultReaderFormatterFacts()
         {
             var mockKeyVault = new Mock<ISecretReader>();
-            mockKeyVault.Setup(x => x.GetSecretAsync(It.IsAny<string>())).Returns((string s) => Task.FromResult(s.ToUpper()));
+            mockKeyVault.Setup(x => x.GetSecretAsync(It.IsAny<string>())).Returns((string s) => Task.FromResult(new Secret(s, s.ToUpper())));
 
             _secretInjector = new SecretInjector(mockKeyVault.Object);
         }

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.KeyVault.Tests
         }
 
         [Theory]
-        [MemberData("_testFormatParameters")]
+        [MemberData(nameof(_testFormatParameters))]
         public async Task TestFormat(string input, string expectedOutput)
         {
             // Act


### PR DESCRIPTION
Added `ISecretWriter`, which allows setting and deleting of Secrets. It will be used by the Secret Rotation job. 

`SetSecretAsync` - Sets the value and tags of a secret and returns the `Secret` that was set. Has two overloads, one which takes in the name, value, and tags directly and another that takes in a `Secret`.

`DeleteSecretAsync` - Deletes a secret and returns the `Secret` that was deleted. Has two overloads, one which takes in the name directly and another that takes in a `Secret`.

I also made several changes to the library necessary to allow writing of secrets.

- Created a `Secret` class, which mostly serves as a layer of abstraction between the consumers of the library and `Microsoft.Azure.KeyVault.Secret`. Additionally, if another source of secrets comes up, it will wrap secrets from those sources as well.
- Modified `GetSecretAsync` in `ISecretReader` to return `Secret`s and not the value directly. Otherwise, it would be impossible to get the tags from the secret. Also added an overload to the method that takes in a `Secret` for simplicity of use.
- Modified `SecretInjector` and some of our unit tests to properly handle the new return type.

Technically, these are breaking changes to the API, but since none of our projects actually use `ISecretReader` directly, instead supplying it to a `SecretInjector`, there should be no necessary code changes.

Also, made a minor fix to `ConfigurationFactory` to prevent an exception from `IConfigurationProvider` from being masked by an error message that does not apply to it.