### PR TITLE
UseBasicParsing for all web requests in Powershell

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -235,7 +235,7 @@ Function Install-NuGet {
     if (-not (Test-Path $CredentialProviderBundle)) {
         Trace-Log 'Downloading VSTS credential provider'
 
-        wget https://msblox.pkgs.visualstudio.com/DefaultCollection/_apis/public/nuget/client/CredentialProviderBundle.zip -OutFile $CredentialProviderBundle
+        wget -UseBasicParsing https://msblox.pkgs.visualstudio.com/DefaultCollection/_apis/public/nuget/client/CredentialProviderBundle.zip -OutFile $CredentialProviderBundle
     }
 
     if (-not (Test-Path $NuGetExe)) {
@@ -246,7 +246,7 @@ Function Install-NuGet {
     }
     
     Trace-Log 'Downloading latest prerelease of nuget.exe'
-    wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $NuGetExe
+    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $NuGetExe
 }
 
 Function Configure-NuGetCredentials {
@@ -304,7 +304,7 @@ Function Install-DotnetCLI {
 
     $installDotnet = Join-Path $CLIRoot "dotnet-install.ps1"
 
-    wget 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
+    wget -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
 
     & $installDotnet -Channel preview -i $CLIRoot -Version 1.0.0-preview2-003121
 

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -28,13 +28,13 @@ Function Download-Folder {
     
     $FolderUri = "$RootGitHubApiUri/$Path$Ref"
     Write-Host "Downloading files from $FolderUri"
-    $Files = wget $FolderUri | ConvertFrom-Json
+    $Files = wget -UseBasicParsing $FolderUri | ConvertFrom-Json
     Foreach ($File in $Files) {
         $FilePath = $File.path
         if ($File.type -eq "file") {
             $DownloadUrl = $File.download_url
             Write-Host "Downloading file at $DownloadUrl"
-            wget -Uri $DownloadUrl -OutFile (Join-Path $NuGetClientRoot $FilePath)
+            wget -UseBasicParsing -Uri $DownloadUrl -OutFile (Join-Path $NuGetClientRoot $FilePath)
         } elseif ($File.type -eq "dir") {
             Download-Folder -Path $FilePath
         }


### PR DESCRIPTION
If web requests are made without this attribute, they will fail on machines that have not completed first-run configuration of Internet Explorer (VSTS hosted build agents).