### PR TITLE
Use AssemblyInfo.g.cs pattern instead of appending to AssemblyInfo.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# Files created and used by our build scripts
+AssemblyInfo.*.cs
+.nuget/CredentialProviderBundle.zip
+nuget.exe
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/build.ps1
+++ b/build.ps1
@@ -65,9 +65,9 @@ Invoke-BuildStep 'Clearing artifacts' { Clear-Artifacts } `
 
 Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
     param($Version, $Branch, $Commit)
-    Set-VersionInfo -Path (Join-Path $PSScriptRoot "src\NuGet.Services.KeyVault\Properties\AssemblyInfo.cs") -Version $Version -Branch $Branch -Commit $Commit
-    Set-VersionInfo -Path (Join-Path $PSScriptRoot "src\NuGet.Services.Logging\Properties\AssemblyInfo.cs") -Version $Version -Branch $Branch -Commit $Commit
-    Set-VersionInfo -Path (Join-Path $PSScriptRoot "src\NuGet.Services.Configuration\Properties\AssemblyInfo.cs") -Version $Version -Branch $Branch -Commit $Commit
+    Set-VersionInfo -Path "$PSScriptRoot\src\NuGet.Services.KeyVault\Properties\AssemblyInfo.g.cs" -Version $Version -Branch $Branch -Commit $Commit
+    Set-VersionInfo -Path "$PSScriptRoot\src\NuGet.Services.Logging\Properties\AssemblyInfo.g.cs" -Version $Version -Branch $Branch -Commit $Commit
+    Set-VersionInfo -Path "$PSScriptRoot\src\NuGet.Services.Configuration\Properties\AssemblyInfo.g.cs" -Version $Version -Branch $Branch -Commit $Commit
     } `
     -args $SimpleVersion, $Branch, $CommitSHA `
     -ev +BuildErrors
@@ -100,7 +100,6 @@ Invoke-BuildStep 'Patching versions of artifacts' {`
         Trace-Log "Patching versions of NuGet packages to $SemanticVersion"
         
         & $NupkgWrenchExe release "$Artifacts" --new-version $SemanticVersion
-        & $NupkgWrenchExe release "$Artifacts\NuGet.Services.Configuration.$SemanticVersion.nupkg" --new-version $SemanticVersion --id "NuGet.Services.KeyVault"
         
         Trace-Log "Done"
     }`

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -534,9 +534,10 @@ Function Set-VersionInfo {
         throw "No version info provided."
     }
     
-    if(!(Test-Path $Path)) {
-        throw "AssemblyInfo.cs not found at $Path!"
+    if (Test-Path $Path) {
+        Remove-Item $Path
     }
+    New-Item $Path -ItemType File
     
     Trace-Log "Getting version info in @""$Path"""
     

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -563,6 +563,15 @@ Function Set-VersionInfo {
     Trace-Log ("[assembly: AssemblyMetadata(""CommitId"", """ + $Commit + """)]")
     Trace-Log ("[assembly: AssemblyMetadata(""BuildDateUtc"", """ + $BuildDateUtc + """)]")
     
+    Add-Content $Path ("// Copyright (c) .NET Foundation. All rights reserved.")
+    Add-Content $Path ("// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.")
+    
+    Add-Content $Path ("`r`nusing System;")
+    Add-Content $Path ("using System.Reflection;")
+    Add-Content $Path ("using System.Resources;")
+    Add-Content $Path ("using System.Runtime.CompilerServices;")
+    Add-Content $Path ("using System.Runtime.InteropServices;")
+    
     Add-Content $Path ("`r`n[assembly: AssemblyVersion(""" + $Version + """)]")
     Add-Content $Path ("[assembly: AssemblyInformationalVersion(""" + $SemanticVersion + """)]")
     Add-Content $Path "#if !PORTABLE"

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -101,6 +101,7 @@
     <Compile Include="KeyVaultReader.cs" />
     <Compile Include="SecretInjector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">


### PR DESCRIPTION
This is necessary so that building all our projects will never lead to a changes on Git.