### PR TITLE
Guarantee SubmoduleBranch is in no "refs/heads/" form

### DIFF
--- a/build/Queue-Build.ps1
+++ b/build/Queue-Build.ps1
@@ -9,6 +9,9 @@ param (
     [string]$SubmoduleBranch
 )
 
+$RefsHeads = 'refs\/heads\/'
+$SubmoduleBranch = $SubmoduleBranch -replace $RefsHeads, ''
+
 $Base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $User, $Password)))
 $Headers = @{Authorization=("Basic {0}" -f $Base64AuthInfo)}
 
@@ -16,7 +19,7 @@ $Headers = @{Authorization=("Basic {0}" -f $Base64AuthInfo)}
 $ListResponse = Invoke-WebRequest -UseBasicParsing -Method Get -Uri "https://$Instance.visualstudio.com/DefaultCollection/$Project/_apis/build/builds?api-version=2.0&definitions=$DefinitionId&statusFilter=notStarted" -Headers $Headers
 $QueuedBuilds = ConvertFrom-Json $ListResponse
 Foreach ($QueuedBuild in $QueuedBuilds.value) {
-    $QueuedBranch = $QueuedBuild.sourceBranch -replace 'refs\/heads\/', ''
+    $QueuedBranch = $QueuedBuild.sourceBranch -replace $RefsHeads, ''
     $QueuedParameters = ConvertFrom-Json $QueuedBuild.parameters
     if ($QueuedBranch -eq $Branch -and $QueuedParameters.SubmoduleBranch -eq $SubmoduleBranch) {
         Write-Host "There is already a build queued!"


### PR DESCRIPTION
After fixing another issue, builds of `NuGetDeployment` started failing when "refs/heads/branchname" was passed as the submodule branch instead of "branchname". This will fix that issue and get our builds running again!