### PR TITLE
Prevent init.ps1 from overwriting variables

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -52,7 +52,7 @@ Function Get-BuildTools {
     }
 }
 
-Get-BuildTools -Branch $Branch
+Get-BuildTools -Branch $BuildBranch
 
 # Run common.ps1
 . "$NuGetClientRoot\build\common.ps1"

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -1,50 +1,58 @@
 [CmdletBinding()]
 param(
-    [string]$Branch
+    [string]$BuildBranch
 )
 
 # This file is downloaded to "build/init.ps1" so use the parent folder as the root
 $NuGetClientRoot = Split-Path -Path $PSScriptRoot -Parent
 
-# Download common.ps1 and other tools used by this build script
-$RootGitHubApiUri = "https://api.github.com/repos/NuGet/ServerCommon/contents"
-
-if ($Branch) {
-    $Ref = '?ref=' + $Branch
-} else {
-    $Ref = ''
-}
-
-Function Download-Folder {
-    [CmdletBinding()]
+Function Get-BuildTools {
     param(
-        [string]$Path
+        [string]$Branch
     )
-    
-    $DirectoryPath = (Join-Path $NuGetClientRoot $FilePath)
-    if (-not (Test-Path $DirectoryPath)) {
-        New-Item -Path $DirectoryPath -ItemType "directory"
+
+    # Download common.ps1 and other tools used by this build script
+    $RootGitHubApiUri = "https://api.github.com/repos/NuGet/ServerCommon/contents"
+
+    if ($Branch) {
+        $Ref = '?ref=' + $Branch
+    } else {
+        $Ref = ''
     }
-    
-    $FolderUri = "$RootGitHubApiUri/$Path$Ref"
-    Write-Host "Downloading files from $FolderUri"
-    $Files = wget -UseBasicParsing $FolderUri | ConvertFrom-Json
-    Foreach ($File in $Files) {
-        $FilePath = $File.path
-        if ($File.type -eq "file") {
-            $DownloadUrl = $File.download_url
-            Write-Host "Downloading file at $DownloadUrl"
-            wget -UseBasicParsing -Uri $DownloadUrl -OutFile (Join-Path $NuGetClientRoot $FilePath)
-        } elseif ($File.type -eq "dir") {
-            Download-Folder -Path $FilePath
+
+    Function Get-Folder {
+        [CmdletBinding()]
+        param(
+            [string]$Path
+        )
+        
+        $DirectoryPath = (Join-Path $NuGetClientRoot $FilePath)
+        if (-not (Test-Path $DirectoryPath)) {
+            New-Item -Path $DirectoryPath -ItemType "directory"
+        }
+        
+        $FolderUri = "$RootGitHubApiUri/$Path$Ref"
+        Write-Host "Downloading files from $FolderUri"
+        $Files = wget -UseBasicParsing $FolderUri | ConvertFrom-Json
+        Foreach ($File in $Files) {
+            $FilePath = $File.path
+            if ($File.type -eq "file") {
+                $DownloadUrl = $File.download_url
+                Write-Host "Downloading file at $DownloadUrl"
+                wget -UseBasicParsing -Uri $DownloadUrl -OutFile (Join-Path $NuGetClientRoot $FilePath)
+            } elseif ($File.type -eq "dir") {
+                Get-Folder -Path $FilePath
+            }
         }
     }
+
+    $FoldersToDownload = "build", "tools"
+    foreach ($Folder in $FoldersToDownload) {
+        Get-Folder -Path $Folder
+    }
 }
 
-$FoldersToDownload = "build", "tools"
-foreach ($Folder in $FoldersToDownload) {
-    Download-Folder -Path $Folder
-}
+Get-BuildTools -Branch $Branch
 
 # Run common.ps1
 . "$NuGetClientRoot\build\common.ps1"


### PR DESCRIPTION
Due to how scopes in PowerShell work, this script was overwriting the branch variable when called using the dot operator.

For example,
```
$Branch = "master"
Write-Host $Branch
. "init.ps1" -Branch "dev"
Write-Host $Branch
```
outputs
```
master
dev
```

By moving the main logic entirely into a function and renaming the parameter to `$BuildBranch` we can prevent `$Branch`, `$RootGitHubApiUri`, `$Ref`, `$FoldersToDownload`, and `$Folder` from being overwritten.