### PR TITLE
Fix MSBuild 15 finder script to work with machines with single instances of VS2017

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -108,6 +108,7 @@ Function Get-MSBuildExe {
         $installations = [NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
             $MSBuildRoot = Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
             Join-Path $MSBuildRoot $MSBuildExeRelPath
+            Trace-Log "Checking for MSBuild at $(Join-Path $MSBuildRoot $MSBuildExeRelPath)"
         } | Where-Object { Test-Path $_ }
         
         $MSBuildPath = $installations[0]

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -110,7 +110,11 @@ Function Get-MSBuildExe {
             Join-Path $MSBuildRoot $MSBuildExeRelPath
         } | Where-Object { Test-Path $_ })
         
-        $MSBuildPath = $installations[0]
+        if ($installations.Count -ge 1) {
+            $MSBuildPath = $installations[0]
+        } else {
+            Error-Log "Failed to find MSBuild $MSBuildVersion!"
+        }
     }
     
     Trace-Log "MSBuild found at $MSBuildPath"

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -105,11 +105,10 @@ Function Get-MSBuildExe {
             }
         }
         
-        $installations = [NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
+        $installations = @([NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
             $MSBuildRoot = Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
             Join-Path $MSBuildRoot $MSBuildExeRelPath
-            Trace-Log "Checking for MSBuild at $(Join-Path $MSBuildRoot $MSBuildExeRelPath)"
-        } | Where-Object { Test-Path $_ }
+        } | Where-Object { Test-Path $_ })
         
         $MSBuildPath = $installations[0]
     }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -81,10 +81,12 @@ Function Get-MSBuildExe {
     param(
         [int]$MSBuildVersion
     )
+    
+    $MSBuildPath = $null
 
     if ($MSBuildVersion -lt 15) {
         $MSBuildExe = Join-Path $MSBuildRoot ([string]$MSBuildVersion + ".0")
-        Join-Path $MSBuildExe $MSBuildExeRelPath
+        $MSBuildPath = Join-Path $MSBuildExe $MSBuildExeRelPath
     } else {
         # Check if VS package to use to find $NuGetBuildPackageId is installed. If not, install it.
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | `
@@ -94,7 +96,7 @@ Function Get-MSBuildExe {
             }))
         {
             Trace-Log "Installing and configuring $NuGetBuildPackageId"
-            $opts = "install", $NuGetBuildPackageId, "-Version", $NuGetBuildPackageVersion, "-OutputDirectory", "$PSScriptRoot\packages"
+            $opts = "install", $NuGetBuildPackageId, "-Version", $NuGetBuildPackageVersion, "-Source", "https://dotnet.myget.org/F/nuget-build/api/v3/index.json", "-OutputDirectory", "$PSScriptRoot\packages"
             & $NuGetExe $opts | Out-Null
             if (-not $?) {
                 Error-Log "Failed to install package $NuGetBuildPackageId $NuGetBuildPackageVersion!"
@@ -104,12 +106,15 @@ Function Get-MSBuildExe {
         }
         
         $installations = [NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
-            $MSBuildExe = Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
-            Join-Path $MSBuildExe $MSBuildExeRelPath
+            $MSBuildRoot = Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
+            Join-Path $MSBuildRoot $MSBuildExeRelPath
         } | Where-Object { Test-Path $_ }
         
-        $installations[0]
+        $MSBuildPath = $installations[0]
     }
+    
+    Trace-Log "MSBuild found at $MSBuildPath"
+    $MSBuildPath
 }
 
 Function Invoke-BuildStep {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -94,7 +94,7 @@ Function Get-MSBuildExe {
             }))
         {
             Trace-Log "Installing and configuring $NuGetBuildPackageId"
-            $opts = "install", $NuGetBuildPackageId, "-Version", $NuGetBuildPackageVersion, "-Source", "https://dotnet.myget.org/F/nuget-build/api/v3/index.json", "-OutputDirectory", "$PSScriptRoot\packages"
+            $opts = "install", $NuGetBuildPackageId, "-Version", $NuGetBuildPackageVersion, "-OutputDirectory", "$PSScriptRoot\packages"
             & $NuGetExe $opts | Out-Null
             if (-not $?) {
                 Error-Log "Failed to install package $NuGetBuildPackageId $NuGetBuildPackageVersion!"


### PR DESCRIPTION
With a single instance, PowerShell was unwrapping the array and returning the first character, not the first string.