### PR TITLE
Included the proper file to have assembly version set properly

### DIFF
--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -51,6 +51,7 @@
     <Compile Include="IStorageFactory.cs" />
     <Compile Include="JTokenStorageContent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="Storage.cs" />
     <Compile Include="StorageContent.cs" />
     <Compile Include="StorageFactory.cs" />


### PR DESCRIPTION
Previous version did not pick up the `AssemblyInfo.g.cs` properly so we ended up with version `0.0.0.0`. This PR contains the fix