### PR TITLE
Added Nuget.Services.Cursor project

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Storage", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Cursor", "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj", "{3269C147-FA0D-4865-83E2-50897C557C82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Cursor.Tests", "tests\NuGet.Services.Cursor.Tests\NuGet.Services.Cursor.Tests.csproj", "{EDB53299-EDC5-4756-989B-A65620D63A14}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +74,10 @@ Global
 		{3269C147-FA0D-4865-83E2-50897C557C82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3269C147-FA0D-4865-83E2-50897C557C82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3269C147-FA0D-4865-83E2-50897C557C82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDB53299-EDC5-4756-989B-A65620D63A14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDB53299-EDC5-4756-989B-A65620D63A14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDB53299-EDC5-4756-989B-A65620D63A14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDB53299-EDC5-4756-989B-A65620D63A14}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,5 +92,6 @@ Global
 		{63000EEE-3579-48E6-A71D-7378A7A1A2F5} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{AED43955-2676-48EC-A27E-6965008D4B3B} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{3269C147-FA0D-4865-83E2-50897C557C82} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
+		{EDB53299-EDC5-4756-989B-A65620D63A14} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -1,11 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-<<<<<<< HEAD
 VisualStudioVersion = 15.0.26501.1
-=======
-VisualStudioVersion = 15.0.26510.0
->>>>>>> develop
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8415FED7-1BED-4227-8B4F-BB7C24E041CD}"
 EndProject

--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26412.1
+VisualStudioVersion = 15.0.26501.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8415FED7-1BED-4227-8B4F-BB7C24E041CD}"
 EndProject
@@ -27,6 +27,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Logging.Tests", "tests\NuGet.Services.Logging.Tests\NuGet.Services.Logging.Tests.csproj", "{63000EEE-3579-48E6-A71D-7378A7A1A2F5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Storage", "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj", "{AED43955-2676-48EC-A27E-6965008D4B3B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Cursor", "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj", "{3269C147-FA0D-4865-83E2-50897C557C82}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -66,6 +68,10 @@ Global
 		{AED43955-2676-48EC-A27E-6965008D4B3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AED43955-2676-48EC-A27E-6965008D4B3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AED43955-2676-48EC-A27E-6965008D4B3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3269C147-FA0D-4865-83E2-50897C557C82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3269C147-FA0D-4865-83E2-50897C557C82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3269C147-FA0D-4865-83E2-50897C557C82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3269C147-FA0D-4865-83E2-50897C557C82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,5 +85,6 @@ Global
 		{7EBF325F-8671-46EF-B065-D9EB4C60B850} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{63000EEE-3579-48E6-A71D-7378A7A1A2F5} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{AED43955-2676-48EC-A27E-6965008D4B3B} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
+		{3269C147-FA0D-4865-83E2-50897C557C82} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 	EndGlobalSection
 EndGlobal

--- a/build.ps1
+++ b/build.ps1
@@ -64,7 +64,8 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\NuGet.Services.Logging\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Configuration\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Build\Properties\AssemblyInfo.g.cs",`
-            "$PSScriptRoot\src\NuGet.Services.Storage\Properties\AssemblyInfo.g.cs"
+            "$PSScriptRoot\src\NuGet.Services.Storage\Properties\AssemblyInfo.g.cs",`
+            "$PSScriptRoot\src\NuGet.Services.Cursor\Properties\AssemblyInfo.g.cs"
             
         $versionMetadata | ForEach-Object {
             Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA
@@ -89,7 +90,8 @@ Invoke-BuildStep 'Creating artifacts' { `
             "src\NuGet.Services.Logging\NuGet.Services.Logging.csproj", `
             "src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj", `
             "src\NuGet.Services.Build\NuGet.Services.Build.csproj",`
-            "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj"
+            "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj",`
+            "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj"
         
         $projects | ForEach-Object {
             New-Package (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -IncludeReferencedProjects -MSBuildVersion "14"

--- a/build.ps1
+++ b/build.ps1
@@ -80,7 +80,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        Build-Solution $Configuration $BuildNumber -MSBuildVersion "14" $SolutionPath -SkipRestore:$SkipRestore
+        Build-Solution $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
     
@@ -94,7 +94,7 @@ Invoke-BuildStep 'Creating artifacts' { `
             "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj"
         
         $projects | ForEach-Object {
-            New-Package (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -IncludeReferencedProjects -MSBuildVersion "14"
+            New-Package (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -IncludeReferencedProjects -MSBuildVersion "15"
         }
     } `
     -ev +BuildErrors

--- a/src/NuGet.Services.Cursor/AggregateCursor.cs
+++ b/src/NuGet.Services.Cursor/AggregateCursor.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Cursor
+{
+    /// <summary>
+    /// A <see cref="ReadCursor"/> that returns the least value for <see cref="Load(CancellationToken)"/> from a set of <see cref="ReadCursor"/>s.
+    /// </summary>
+    public class AggregateCursor<T> : ReadCursor<T>
+    {
+        public AggregateCursor(IEnumerable<ReadCursor<T>> innerCursors)
+        {
+            if (innerCursors == null || innerCursors.Count() < 1)
+            {
+                throw new ArgumentException("Must supply at least one cursor!", nameof(innerCursors));
+            }
+
+            InnerCursors = innerCursors.ToList();
+        }
+
+        public IEnumerable<ReadCursor<T>> InnerCursors { get; private set; }
+
+        public override async Task Load(CancellationToken cancellationToken)
+        {
+            await Task.WhenAll(InnerCursors.Select(c => c.Load(cancellationToken)));
+            Value = InnerCursors.Min(c => c.Value);
+        }
+    }
+}

--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Services.Storage;
+
+namespace NuGet.Services.Cursor
+{
+    public class DurableCursor : ReadWriteCursor
+    {
+        Uri _address;
+        Storage.Storage _storage;
+        DateTime _defaultValue;
+
+        public DurableCursor(Uri address, Storage.Storage storage, DateTime defaultValue)
+        {
+            _address = address;
+            _storage = storage;
+            _defaultValue = defaultValue;
+        }
+
+        public override async Task Save(CancellationToken cancellationToken)
+        {
+            JObject obj = new JObject { { "value", Value.ToString("O") } };
+            StorageContent content = new StringStorageContent(obj.ToString(), "application/json", "no-store");
+            await _storage.Save(_address, content, cancellationToken);
+        }
+
+        public override async Task Load(CancellationToken cancellationToken)
+        {
+            string json = await _storage.LoadString(_address, cancellationToken);
+
+            if (json == null)
+            {
+                Value = _defaultValue;
+                return;
+            }
+
+            JObject obj = JObject.Parse(json);
+            Value = obj["value"].ToObject<DateTime>();
+        }
+    }
+}

--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -16,8 +16,8 @@ namespace NuGet.Services.Cursor
 
         public DurableCursor(Uri address, Storage.Storage storage, DateTimeOffset defaultValue)
         {
-            _address = address;
-            _storage = storage;
+            _address = address ?? throw new ArgumentNullException(nameof(address));
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _defaultValue = defaultValue;
         }
 

--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -12,9 +12,9 @@ namespace NuGet.Services.Cursor
     {
         Uri _address;
         Storage.Storage _storage;
-        DateTime _defaultValue;
+        DateTimeOffset _defaultValue;
 
-        public DurableCursor(Uri address, Storage.Storage storage, DateTime defaultValue)
+        public DurableCursor(Uri address, Storage.Storage storage, DateTimeOffset defaultValue)
         {
             _address = address;
             _storage = storage;
@@ -39,7 +39,7 @@ namespace NuGet.Services.Cursor
             }
 
             JObject obj = JObject.Parse(json);
-            Value = obj["value"].ToObject<DateTime>();
+            Value = obj["value"].ToObject<DateTimeOffset>();
         }
     }
 }

--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -8,7 +8,7 @@ using NuGet.Services.Storage;
 
 namespace NuGet.Services.Cursor
 {
-    public class DurableCursor : ReadWriteCursor
+    public class DurableCursor : ReadWriteCursor<DateTimeOffset>
     {
         Uri _address;
         Storage.Storage _storage;

--- a/src/NuGet.Services.Cursor/HttpReadCursor.cs
+++ b/src/NuGet.Services.Cursor/HttpReadCursor.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Cursor
                 string json = await response.Content.ReadAsStringAsync();
 
                 JObject obj = JObject.Parse(json);
-                Value = obj["value"].ToObject<DateTime>();
+                Value = obj["value"].ToObject<DateTimeOffset>();
             }
 
             Trace.TraceInformation("HttpReadCursor.Load: {0}", this);

--- a/src/NuGet.Services.Cursor/HttpReadCursor.cs
+++ b/src/NuGet.Services.Cursor/HttpReadCursor.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 
 namespace NuGet.Services.Cursor
 {
-    public class HttpReadCursor : ReadCursor
+    public class HttpReadCursor : ReadCursor<DateTimeOffset>
     {
         Uri _address;
         Func<HttpMessageHandler> _handlerFunc;

--- a/src/NuGet.Services.Cursor/HttpReadCursor.cs
+++ b/src/NuGet.Services.Cursor/HttpReadCursor.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Services.Cursor
+{
+    public class HttpReadCursor : ReadCursor
+    {
+        Uri _address;
+        Func<HttpMessageHandler> _handlerFunc;
+
+        public HttpReadCursor(Uri address, Func<HttpMessageHandler> handlerFunc = null)
+        {
+            _address = address;
+            _handlerFunc = handlerFunc;
+        }
+
+        public override async Task Load(CancellationToken cancellationToken)
+        {
+            HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new WebRequestHandler { AllowPipelining = true };
+
+            using (HttpClient client = new HttpClient(handler))
+            {
+                HttpResponseMessage response = await client.GetAsync(_address, cancellationToken);
+
+                Trace.TraceInformation("HttpReadCursor.Load {0}", response.StatusCode);
+
+                response.EnsureSuccessStatusCode();
+
+                string json = await response.Content.ReadAsStringAsync();
+
+                JObject obj = JObject.Parse(json);
+                Value = obj["value"].ToObject<DateTime>();
+            }
+
+            Trace.TraceInformation("HttpReadCursor.Load: {0}", this);
+        }
+    }
+}

--- a/src/NuGet.Services.Cursor/MemoryCursor.cs
+++ b/src/NuGet.Services.Cursor/MemoryCursor.cs
@@ -8,13 +8,13 @@ namespace NuGet.Services.Cursor
 {
     public class MemoryCursor : ReadWriteCursor<DateTimeOffset>
     {
-        public static DateTime MinValue = DateTime.MinValue.ToUniversalTime();
-        public static DateTime MaxValue = DateTime.MaxValue.ToUniversalTime();
+        public static DateTimeOffset MinValue = DateTimeOffset.MinValue.ToUniversalTime();
+        public static DateTimeOffset MaxValue = DateTimeOffset.MaxValue.ToUniversalTime();
 
         public static MemoryCursor CreateMin() { return new MemoryCursor(MinValue); }
         public static MemoryCursor CreateMax() { return new MemoryCursor(MaxValue); }
 
-        public MemoryCursor(DateTime value)
+        public MemoryCursor(DateTimeOffset value)
         {
             Value = value;
         }

--- a/src/NuGet.Services.Cursor/MemoryCursor.cs
+++ b/src/NuGet.Services.Cursor/MemoryCursor.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Cursor
+{
+    public class MemoryCursor : ReadWriteCursor
+    {
+        public static DateTime MinValue = DateTime.MinValue.ToUniversalTime();
+        public static DateTime MaxValue = DateTime.MaxValue.ToUniversalTime();
+
+        public static MemoryCursor CreateMin() { return new MemoryCursor(MinValue); }
+        public static MemoryCursor CreateMax() { return new MemoryCursor(MaxValue); }
+
+        public MemoryCursor(DateTime value)
+        {
+            Value = value;
+        }
+
+        public MemoryCursor()
+        {
+            // TODO: Complete member initialization
+        }
+
+        public override Task Load(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(0);
+        }
+
+        public override Task Save(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/NuGet.Services.Cursor/MemoryCursor.cs
+++ b/src/NuGet.Services.Cursor/MemoryCursor.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.Cursor
 {
-    public class MemoryCursor : ReadWriteCursor
+    public class MemoryCursor : ReadWriteCursor<DateTimeOffset>
     {
         public static DateTime MinValue = DateTime.MinValue.ToUniversalTime();
         public static DateTime MaxValue = DateTime.MaxValue.ToUniversalTime();

--- a/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
+++ b/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AggregateCursor.cs" />
     <Compile Include="DurableCursor.cs" />
     <Compile Include="HttpReadCursor.cs" />
     <Compile Include="MemoryCursor.cs" />

--- a/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
+++ b/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3269C147-FA0D-4865-83E2-50897C557C82}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.Cursor</RootNamespace>
+    <AssemblyName>NuGet.Services.Cursor</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DurableCursor.cs" />
+    <Compile Include="HttpReadCursor.cs" />
+    <Compile Include="MemoryCursor.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="ReadCursor.cs" />
+    <Compile Include="ReadWriteCursor.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.Storage\NuGet.Services.Storage.csproj">
+      <Project>{aed43955-2676-48ec-a27e-6965008d4b3b}</Project>
+      <Name>NuGet.Services.Storage</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
+++ b/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
@@ -59,4 +59,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\sign.targets" />
 </Project>

--- a/src/NuGet.Services.Cursor/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.Cursor/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.Services.Cursor")]
+[assembly: AssemblyDescription("Shared cursor classes")]
+[assembly: AssemblyCompany(".NET Foundation")]
+[assembly: AssemblyProduct("NuGet.Services.Cursor")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2017")]
+[assembly: ComVisible(false)]
+[assembly: Guid("3269c147-fa0d-4865-83e2-50897c557c82")]

--- a/src/NuGet.Services.Cursor/ReadCursor.cs
+++ b/src/NuGet.Services.Cursor/ReadCursor.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.Cursor
 {
     public abstract class ReadCursor<T>
     {
-        public T Value { get; set; }
+        public virtual T Value { get; set; }
 
         public abstract Task Load(CancellationToken cancellationToken);
     }

--- a/src/NuGet.Services.Cursor/ReadCursor.cs
+++ b/src/NuGet.Services.Cursor/ReadCursor.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Cursor
+{
+    public abstract class ReadCursor
+    {
+        public DateTime Value { get; set; }
+
+        public abstract Task Load(CancellationToken cancellationToken);
+
+        public override string ToString()
+        {
+            return Value.ToString("O");
+        }
+    }
+}

--- a/src/NuGet.Services.Cursor/ReadCursor.cs
+++ b/src/NuGet.Services.Cursor/ReadCursor.cs
@@ -6,15 +6,10 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.Cursor
 {
-    public abstract class ReadCursor
+    public abstract class ReadCursor<T>
     {
-        public DateTime Value { get; set; }
+        public T Value { get; set; }
 
         public abstract Task Load(CancellationToken cancellationToken);
-
-        public override string ToString()
-        {
-            return Value.ToString("O");
-        }
     }
 }

--- a/src/NuGet.Services.Cursor/ReadWriteCursor.cs
+++ b/src/NuGet.Services.Cursor/ReadWriteCursor.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Cursor
+{
+    public abstract class ReadWriteCursor : ReadCursor
+    {
+        public abstract Task Save(CancellationToken cancellationToken);
+    }
+}

--- a/src/NuGet.Services.Cursor/ReadWriteCursor.cs
+++ b/src/NuGet.Services.Cursor/ReadWriteCursor.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.Cursor
 {
-    public abstract class ReadWriteCursor : ReadCursor
+    public abstract class ReadWriteCursor<T> : ReadCursor<T>
     {
         public abstract Task Save(CancellationToken cancellationToken);
     }

--- a/src/NuGet.Services.Cursor/project.json
+++ b/src/NuGet.Services.Cursor/project.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "frameworks": {
+    "net452": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}

--- a/tests/NuGet.Services.Cursor.Tests/AggregateCursorTests.cs
+++ b/tests/NuGet.Services.Cursor.Tests/AggregateCursorTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.Cursor.Tests
+{
+    public class AggregateCursorTests
+    {
+        [Fact]
+        public void ThrowsIfNoCursors()
+        {
+            Assert.Throws<ArgumentException>(() => new AggregateCursor<DateTimeOffset>(null));
+            Assert.Throws<ArgumentException>(() => new AggregateCursor<DateTimeOffset>(new List<ReadCursor<DateTimeOffset>>()));
+        }
+
+        public static IEnumerable<object[]> ReturnsLeastValue_data
+        {
+            get
+            {
+                // Single
+                yield return new object[]
+                {
+                    new List<DateTime>
+                    {
+                        new DateTime(2017, 4, 13)
+                    }
+                };
+
+                // Two with least first
+                yield return new object[]
+                {
+                    new List<DateTime>
+                    {
+                        new DateTime(2017, 4, 13),
+                        new DateTime(2017, 4, 14)
+                    }
+                };
+
+                // Two with least last
+                yield return new object[]
+                {
+                    new List<DateTime>
+                    {
+                        new DateTime(2017, 4, 14),
+                        new DateTime(2017, 4, 13)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ReturnsLeastValue_data))]
+        public async Task ReturnsLeastValue(IEnumerable<DateTime> dates)
+        {
+            // Arrange
+            var cursors = dates.Select(d => CreateReadCursor(d));
+            var aggregateCursor = new AggregateCursor<DateTime>(cursors);
+
+            // Act
+            await aggregateCursor.Load(CancellationToken.None);
+            var value = aggregateCursor.Value;
+
+            // Assert
+            Assert.Equal(dates.Min(), value);
+        }
+
+        private ReadCursor<DateTime> CreateReadCursor(DateTime date)
+        {
+            var cursor = new Mock<ReadCursor<DateTime>>();
+            cursor.Setup(x => x.Value).Returns(() =>
+            {
+                cursor.Verify(x => x.Load(It.IsAny<CancellationToken>()));
+                return date;
+            });
+
+            return cursor.Object;
+        }
+    }
+}

--- a/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
+++ b/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
@@ -87,12 +87,8 @@ namespace NuGet.Services.Cursor.Tests
         private static Mock<Storage.Storage> CreateStorageMock()
         {
             var loggerMock = new Mock<ILogger<Storage.Storage>>();
-            var loggerFactoryMock = new Mock<ILoggerFactory>();
-            loggerFactoryMock
-                .Setup(f => f.CreateLogger(It.IsAny<string>()))
-                .Returns(loggerMock.Object);
 
-            return new Mock<Storage.Storage>(MockBehavior.Strict, new Uri("http://localhost/"), loggerFactoryMock.Object);
+            return new Mock<Storage.Storage>(MockBehavior.Strict, new Uri("http://localhost/"), loggerMock.Object);
         }
     }
 }

--- a/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
+++ b/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using NuGet.Services.Storage;
+using Xunit;
+
+namespace NuGet.Services.Cursor.Tests
+{
+    public class DurableCursorFacts
+    {
+        [Fact]
+        public void SavesToStorage()
+        {
+            var storageMock = CreateStorageMock();
+            storageMock
+                .Protected().Setup<Task>("OnSave", ItExpr.IsAny<Uri>(), ItExpr.IsAny<StorageContent>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(0))
+                .Verifiable();
+
+            var durableCursor = new DurableCursor(new Uri("http://localhost/cursor.json"), storageMock.Object, new DateTimeOffset(2017, 5, 5, 17, 8, 42, TimeSpan.Zero));
+            durableCursor.Save(CancellationToken.None).Wait();
+            storageMock.Verify();
+        }
+
+        [Fact]
+        public void LoadsFromStorage()
+        {
+            var storageMock = CreateStorageMock();
+            storageMock
+                .Protected().Setup<Task>("OnLoad", ItExpr.IsAny<Uri>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult<StorageContent>(null))
+                .Verifiable();
+
+            var durableCursor = new DurableCursor(new Uri("http://localhost/cursor.json"), storageMock.Object, new DateTimeOffset(2017, 5, 5, 17, 8, 42, TimeSpan.Zero));
+            durableCursor.Load(CancellationToken.None).Wait();
+            storageMock.Verify();
+        }
+
+        [Fact]
+        public void UsesDefaultValue()
+        {
+            var storageMock = CreateStorageMock();
+            storageMock
+                .Protected().Setup<Task>("OnLoad", ItExpr.IsAny<Uri>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult<StorageContent>(null));
+
+            DateTimeOffset defaultValue = new DateTimeOffset(2017, 5, 5, 17, 8, 42, TimeSpan.Zero);
+            var durableCursor = new DurableCursor(new Uri("http://localhost/cursor.json"), storageMock.Object, defaultValue);
+            durableCursor.Load(CancellationToken.None).Wait();
+
+            Assert.Equal(defaultValue, durableCursor.Value);
+        }
+
+        private static Mock<Storage.Storage> CreateStorageMock()
+        {
+            var loggerMock = new Mock<ILogger<Storage.Storage>>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock
+                .Setup(f => f.CreateLogger(It.IsAny<string>()))
+                .Returns(loggerMock.Object);
+
+            return new Mock<Storage.Storage>(MockBehavior.Strict, new Uri("http://localhost/"), loggerFactoryMock.Object);
+        }
+    }
+}

--- a/tests/NuGet.Services.Cursor.Tests/NuGet.Services.Cursor.Tests.csproj
+++ b/tests/NuGet.Services.Cursor.Tests/NuGet.Services.Cursor.Tests.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AggregateCursorTests.cs" />
     <Compile Include="DurableCursorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/NuGet.Services.Cursor.Tests/NuGet.Services.Cursor.Tests.csproj
+++ b/tests/NuGet.Services.Cursor.Tests/NuGet.Services.Cursor.Tests.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EDB53299-EDC5-4756-989B-A65620D63A14}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.Cursor.Tests</RootNamespace>
+    <AssemblyName>NuGet.Services.Cursor.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DurableCursorFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj">
+      <Project>{3269c147-fa0d-4865-83e2-50897c557c82}</Project>
+      <Name>NuGet.Services.Cursor</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NuGet.Services.Storage\NuGet.Services.Storage.csproj">
+      <Project>{aed43955-2676-48ec-a27e-6965008d4b3b}</Project>
+      <Name>NuGet.Services.Storage</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/NuGet.Services.Cursor.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NuGet.Services.Cursor.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.Services.Cursor.Tests")]
+[assembly: AssemblyDescription("Unit tests for the Cursor library")]
+[assembly: AssemblyCompany(".NET Foundation")]
+[assembly: AssemblyProduct("NuGet.Services.Cursor.Tests")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2017")]
+[assembly: ComVisible(false)]
+[assembly: Guid("edb53299-edc5-4756-989b-a65620d63a14")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NuGet.Services.Cursor.Tests/project.json
+++ b/tests/NuGet.Services.Cursor.Tests/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "dependencies": {
+    "Moq": "4.5.23",
+    "xunit": "2.1.0",
+    "xunit.runner.visualstudio": "2.1.0"
+  },
+  "frameworks": {
+    "net452": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}


### PR DESCRIPTION
Copied cursors from the Nuget.Services.Metadata.
Made the base classes generics.
Made the concrete classes to use `DateTimeOffset` types instead of `DateTime` - migration should be pretty easy since the serialization is done with `dateTime.ToString("O")` and serialized string can be deserialized to `DateTimeOffset` without any additional effort.
Added tests for the `DurableCursor` class.