### PR TITLE
Add Application Insights Processor for Response Codes

### DIFF
--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="TelemetryContextInitializer.cs" />
+    <Compile Include="TelemetryResponseCodeProcessor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
+++ b/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace NuGet.Services.Logging
+{
+    /// <summary>
+    /// Application Insights inspects a request's response code to decide if the operation
+    /// was successful or not. This processor can be used to override the default behavior.
+    /// </summary>
+    public class TelemetryResponseCodeProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor _next;
+
+        /// <summary>
+        /// The response codes that should always be marked as successful.
+        /// </summary>
+        public int[] SuccessfulResponseCodes { get; set; }
+
+        public TelemetryResponseCodeProcessor(ITelemetryProcessor next)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public void Process(ITelemetry item)
+        {
+            var request = item as RequestTelemetry;
+            int responseCode;
+
+            if (request != null && int.TryParse(request.ResponseCode, out responseCode))
+            {
+                if (SuccessfulResponseCodes.Contains(responseCode))
+                {
+                    request.Success = true;
+                }
+            }
+
+            _next.Process(item);
+        }
+    }
+}

--- a/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
+++ b/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="LoggingSetupTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TelemetryResponseCodeProcessorFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGet.Services.Logging\NuGet.Services.Logging.csproj">

--- a/tests/NuGet.Services.Logging.Tests/TelemetryResponseCodeProcessorFacts.cs
+++ b/tests/NuGet.Services.Logging.Tests/TelemetryResponseCodeProcessorFacts.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Xunit;
+
+namespace NuGet.Services.Logging.Tests
+{
+    public class TelemetryResponseCodeProcessorFacts
+    {
+        [Theory]
+        [InlineData(new int[] { 401 }, "401")]
+        [InlineData(new int[] { 400, 404 }, "400")]
+        [InlineData(new int[] { 400, 404 }, "404")]
+        public void MarksOverridenResponseCodesAsSuccessful(int[] responseCodeOverrides, string responseCode)
+        {
+            // Arrange
+            var failed = new RequestTelemetry
+            {
+                ResponseCode = responseCode,
+                Success = false,
+            };
+
+            var successful = new RequestTelemetry
+            {
+                ResponseCode = responseCode,
+                Success = true,
+            };
+
+            // Assert
+            Assert.True(ProcessResponseCode(responseCodeOverrides, failed).Success);
+            Assert.True(ProcessResponseCode(responseCodeOverrides, successful).Success);
+        }
+
+        [Theory]
+        [InlineData(new int[] { 200 }, "400")]
+        [InlineData(new int[] { 400, 404 }, "200")]
+        [InlineData(new int[] { 400, 404 }, "301")]
+        [InlineData(new int[] { 400, 404 }, "401")]
+        [InlineData(new int[] { 400, 404 }, "403")]
+        [InlineData(new int[] { 400, 404 }, "410")]
+        [InlineData(new int[] { 400, 404 }, "500")]
+        public void DoesntAffectOtherResponses(int[] responseCodeOverrides, string responseCode)
+        {
+            // Arrange
+            var failed = new RequestTelemetry
+            {
+                ResponseCode = responseCode,
+                Success = false,
+            };
+
+            var successful = new RequestTelemetry
+            {
+                ResponseCode = responseCode,
+                Success = true,
+            };
+
+            // Assert
+            Assert.False(ProcessResponseCode(responseCodeOverrides, failed).Success);
+            Assert.True(ProcessResponseCode(responseCodeOverrides, successful).Success);
+        }
+
+        private class TelemetryCallbackProcessor : ITelemetryProcessor
+        {
+            private Action<ITelemetry> _callback;
+
+            public TelemetryCallbackProcessor(Action<ITelemetry> callback)
+            {
+                _callback = callback;
+            }
+
+            public void Process(ITelemetry item)
+            {
+                _callback(item);
+            }
+        }
+
+        private RequestTelemetry ProcessResponseCode(int[] responseCodeOverrides, RequestTelemetry telemetry)
+        {
+            ITelemetry result = null;
+            var processor = new TelemetryResponseCodeProcessor(new TelemetryCallbackProcessor(i => result = i));
+
+            processor.SuccessfulResponseCodes = responseCodeOverrides;
+            processor.Process(telemetry);
+
+            return result as RequestTelemetry;
+        }
+    }
+}


### PR DESCRIPTION
This adds the [Gallery's `TelemetryResponseCodeFilter`](https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery/Telemetry/TelemetryResponseCodeFilter.cs) to this common repository so that it can be used by both the Gallery and the Search Service. I tweaked the name and added some basic tests.

Related to [Gallery #3793](https://github.com/NuGet/NuGetGallery/issues/3793)