### PR TITLE
Support specifying KeyVault certificate directly rather than by thumbprint

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -34,17 +34,20 @@ namespace NuGet.Services.Configuration
                 return new EmptySecretReader();
             }
 
+            var certificate = CertificateUtility.FindCertificateByThumbprint(
+                !string.IsNullOrEmpty(_storeName)
+                    ? (StoreName)Enum.Parse(typeof(StoreName), _storeName)
+                    : StoreName.My,
+                !string.IsNullOrEmpty(_storeLocation)
+                    ? (StoreLocation)Enum.Parse(typeof(StoreLocation), _storeLocation)
+                    : StoreLocation.LocalMachine,
+                _certificateThumbprint,
+                _validateCertificate);
+
             var keyVaultConfiguration = new KeyVaultConfiguration(
                 _vaultName,
                 _clientId,
-                _certificateThumbprint,
-                !string.IsNullOrEmpty(_storeName) 
-                    ? (StoreName) Enum.Parse(typeof(StoreName), _storeName)
-                    : StoreName.My,
-                !string.IsNullOrEmpty(_storeLocation)
-                    ? (StoreLocation) Enum.Parse(typeof(StoreLocation), _storeLocation)
-                    : StoreLocation.LocalMachine,
-                _validateCertificate);
+                certificate);
 
             return new KeyVaultReader(keyVaultConfiguration);
         }

--- a/src/NuGet.Services.KeyVault/CertificateUtility.cs
+++ b/src/NuGet.Services.KeyVault/CertificateUtility.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Services.KeyVault
+{
+    public static class CertificateUtility
+    {
+        public static X509Certificate2 FindCertificateByThumbprint(StoreName storeName, StoreLocation storeLocation, string thumbprint, bool validationRequired)
+        {
+            var store = new X509Store(storeName, storeLocation);
+            try
+            {
+                store.Open(OpenFlags.ReadOnly);
+                var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
+                if (col.Count == 0)
+                {
+                    throw new ArgumentException(
+                        $"Certificate with thumbprint {thumbprint} and validation {(validationRequired ? "required" : "not required")} was not found in store {storeLocation} {storeName}.");
+                }
+
+                return col[0];
+            }
+            finally
+            {
+                store.Close();
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -11,12 +11,7 @@ namespace NuGet.Services.KeyVault
         public string VaultName { get; }
         public string ClientId { get; }
         public X509Certificate2 Certificate { get; }
-
-        public KeyVaultConfiguration(string vaultName, string clientId, string certificateThumbprint, StoreName storeName, StoreLocation storeLocation, bool validateCertificate)
-            : this(vaultName, clientId, FindCertificateByThumbprint(storeName, storeLocation, certificateThumbprint, validateCertificate))
-        {
-        }
-
+        
         public KeyVaultConfiguration(string vaultName, string clientId, X509Certificate2 certificate)
         {
             if (string.IsNullOrWhiteSpace(vaultName))
@@ -32,27 +27,6 @@ namespace NuGet.Services.KeyVault
             VaultName = vaultName;
             ClientId = clientId;
             Certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
-        }
-
-        private static X509Certificate2 FindCertificateByThumbprint(StoreName storeName, StoreLocation storeLocation, string thumbprint, bool validationRequired)
-        {
-            var store = new X509Store(storeName, storeLocation);
-            try
-            {
-                store.Open(OpenFlags.ReadOnly);
-                var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
-                if (col.Count == 0)
-                {
-                    throw new ArgumentException(
-                        $"Certificate with thumbprint {thumbprint} and validation {(validationRequired ? "required" : "not required")} was not found in store {storeLocation} {storeName}.");
-                }
-
-                return col[0];
-            }
-            finally
-            {
-                store.Close();
-            }
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -10,12 +10,14 @@ namespace NuGet.Services.KeyVault
     {
         public string VaultName { get; }
         public string ClientId { get; }
-        public string CertificateThumbprint { get; }
-        public StoreName StoreName { get; }
-        public StoreLocation StoreLocation { get; set; }
-        public bool ValidateCertificate { get; }
+        public X509Certificate2 Certificate { get; }
 
         public KeyVaultConfiguration(string vaultName, string clientId, string certificateThumbprint, StoreName storeName, StoreLocation storeLocation, bool validateCertificate)
+            : this(vaultName, clientId, FindCertificateByThumbprint(storeName, storeLocation, certificateThumbprint, validateCertificate))
+        {
+        }
+
+        public KeyVaultConfiguration(string vaultName, string clientId, X509Certificate2 certificate)
         {
             if (string.IsNullOrWhiteSpace(vaultName))
             {
@@ -26,18 +28,31 @@ namespace NuGet.Services.KeyVault
             {
                 throw new ArgumentNullException(nameof(clientId));
             }
-
-            if (string.IsNullOrWhiteSpace(certificateThumbprint))
-            {
-                throw new ArgumentNullException(nameof(certificateThumbprint));
-            }
-
+            
             VaultName = vaultName;
             ClientId = clientId;
-            CertificateThumbprint = certificateThumbprint;
-            ValidateCertificate = validateCertificate;
-            StoreName = storeName;
-            StoreLocation = storeLocation;
+            Certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
+        }
+
+        private static X509Certificate2 FindCertificateByThumbprint(StoreName storeName, StoreLocation storeLocation, string thumbprint, bool validationRequired)
+        {
+            var store = new X509Store(storeName, storeLocation);
+            try
+            {
+                store.Open(OpenFlags.ReadOnly);
+                var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
+                if (col.Count == 0)
+                {
+                    throw new ArgumentException(
+                        $"Certificate with thumbprint {thumbprint} and validation {(validationRequired ? "required" : "not required")} was not found in store {storeLocation} {storeName}.");
+                }
+
+                return col[0];
+            }
+            finally
+            {
+                store.Close();
+            }
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -40,12 +40,7 @@ namespace NuGet.Services.KeyVault
 
         private KeyVaultClient InitializeClient()
         {
-            var certificate = FindCertificateByThumbprint(
-                _configuration.StoreName,
-                _configuration.StoreLocation,
-                _configuration.CertificateThumbprint,
-                _configuration.ValidateCertificate);
-            _clientAssertionCertificate = new ClientAssertionCertificate(_configuration.ClientId, certificate);
+            _clientAssertionCertificate = new ClientAssertionCertificate(_configuration.ClientId, _configuration.Certificate);
 
             return new KeyVaultClient(GetTokenAsync);
         }
@@ -61,27 +56,6 @@ namespace NuGet.Services.KeyVault
             }
 
             return result.AccessToken;
-        }
-
-        private static X509Certificate2 FindCertificateByThumbprint(StoreName storeName, StoreLocation storeLocation, string thumbprint, bool validationRequired)
-        {
-            var store = new X509Store(storeName, storeLocation);
-            try
-            {
-                store.Open(OpenFlags.ReadOnly);
-                var col = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validationRequired);
-                if (col.Count == 0)
-                {
-                    throw new ArgumentException(
-                        $"Certificate with thumbprint {thumbprint} and validation {(validationRequired ? "required" : "not required")} was not found in store {storeLocation} {storeName}.");
-                }
-
-                return col[0];
-            }
-            finally
-            {
-                store.Close();
-            }
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachingSecretReader.cs" />
+    <Compile Include="CertificateUtility.cs" />
     <Compile Include="ISecretReaderFactory.cs" />
     <Compile Include="EmptySecretReader.cs" />
     <Compile Include="ISecretInjector.cs" />


### PR DESCRIPTION
The V3 monitoring job must use another means to find the certificate rather than by the thumbprint. This change will allow me to find the certificate myself and then pass it to my `KeyVaultReader`.