### PR TITLE
Tweaked TelemetryResponseCodeProcessor 

### DIFF
--- a/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
+++ b/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.ApplicationInsights.Extensibility;
+using System.Collections.Generic;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace NuGet.Services.Logging
 {

--- a/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
+++ b/src/NuGet.Services.Logging/TelemetryResponseCodeProcessor.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
+using System.Collections.Generic;
 
 namespace NuGet.Services.Logging
 {
@@ -20,7 +20,7 @@ namespace NuGet.Services.Logging
         /// <summary>
         /// The response codes that should always be marked as successful.
         /// </summary>
-        public int[] SuccessfulResponseCodes { get; set; }
+        public IList<int> SuccessfulResponseCodes { get; } = new List<int>();
 
         public TelemetryResponseCodeProcessor(ITelemetryProcessor next)
         {

--- a/tests/NuGet.Services.Logging.Tests/TelemetryResponseCodeProcessorFacts.cs
+++ b/tests/NuGet.Services.Logging.Tests/TelemetryResponseCodeProcessorFacts.cs
@@ -78,12 +78,16 @@ namespace NuGet.Services.Logging.Tests
             }
         }
 
-        private RequestTelemetry ProcessResponseCode(int[] responseCodeOverrides, RequestTelemetry telemetry)
+        private RequestTelemetry ProcessResponseCode(int[] successCodeOverrides, RequestTelemetry telemetry)
         {
             ITelemetry result = null;
             var processor = new TelemetryResponseCodeProcessor(new TelemetryCallbackProcessor(i => result = i));
 
-            processor.SuccessfulResponseCodes = responseCodeOverrides;
+            foreach (var successCode in successCodeOverrides)
+            {
+                processor.SuccessfulResponseCodes.Add(successCode);
+            }
+
             processor.Process(telemetry);
 
             return result as RequestTelemetry;


### PR DESCRIPTION
Application Insight's configuration file doesn't play nice with configurable properties that are arrays. This changes the `TelemetryResponseCodeProcessor` to use an `IList` to follow the pattern set by Application Insight's `RequestTrackingTelemetryModule`'s `Handlers` configurable property.