### PR TITLE
ForceSslMiddleware now allows to exclude certain paths from redirection.

### DIFF
--- a/src/NuGet.Services.Owin/ForceSslMiddleware.cs
+++ b/src/NuGet.Services.Owin/ForceSslMiddleware.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 
@@ -15,21 +14,21 @@ namespace NuGet.Services.Owin
     public class ForceSslMiddleware : OwinMiddleware
     {
         private readonly int _sslPort;
-        private readonly List<Regex> _exclusionPathPatterns;
+        private readonly HashSet<string> _exclusionPathPatterns;
 
         public ForceSslMiddleware(OwinMiddleware next, int sslPort)
-            : this(next, sslPort, Enumerable.Empty<Regex>())
+            : this(next, sslPort, Enumerable.Empty<string>())
         {
         }
 
         public ForceSslMiddleware(
             OwinMiddleware next, 
             int sslPort, 
-            IEnumerable<Regex> exclusionPathPatterns)
+            IEnumerable<string> exclusionPathPatterns)
             : base(next ?? throw new ArgumentNullException(nameof(next)))
         {
             _sslPort = sslPort;
-            _exclusionPathPatterns = exclusionPathPatterns.ToList();
+            _exclusionPathPatterns = new HashSet<string>(exclusionPathPatterns);
         }
 
         public override async Task Invoke(IOwinContext context)
@@ -60,7 +59,7 @@ namespace NuGet.Services.Owin
 
         private bool IsExcludedPath(string path)
         {
-            return _exclusionPathPatterns.Any(p => p.IsMatch(path));
+            return _exclusionPathPatterns.Contains(path);
         }
 
         private static bool IsAllowedMethod(string method)

--- a/src/NuGet.Services.Owin/ForceSslMiddleware.cs
+++ b/src/NuGet.Services.Owin/ForceSslMiddleware.cs
@@ -28,7 +28,7 @@ namespace NuGet.Services.Owin
             : base(next ?? throw new ArgumentNullException(nameof(next)))
         {
             _sslPort = sslPort;
-            _exclusionPathPatterns = new HashSet<string>(exclusionPathPatterns);
+            _exclusionPathPatterns = new HashSet<string>(exclusionPathPatterns, StringComparer.OrdinalIgnoreCase);
         }
 
         public override async Task Invoke(IOwinContext context)

--- a/src/NuGet.Services.Owin/ForceSslMiddlewareExtensions.cs
+++ b/src/NuGet.Services.Owin/ForceSslMiddlewareExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NuGet.Services.Owin;
 
 namespace Owin
@@ -15,6 +17,11 @@ namespace Owin
         public static IAppBuilder UseForceSsl(this IAppBuilder appBuilder, int sslPort)
         {
             return appBuilder.Use<ForceSslMiddleware>(sslPort);
+        }
+
+        public static IAppBuilder UseForceSsl(this IAppBuilder appBuilder, int sslPort, IEnumerable<Regex> excludedPathPatterns)
+        {
+            return appBuilder.Use<ForceSslMiddleware>(sslPort, excludedPathPatterns);
         }
     }
 }

--- a/src/NuGet.Services.Owin/ForceSslMiddlewareExtensions.cs
+++ b/src/NuGet.Services.Owin/ForceSslMiddlewareExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using NuGet.Services.Owin;
 
 namespace Owin
@@ -19,9 +18,9 @@ namespace Owin
             return appBuilder.Use<ForceSslMiddleware>(sslPort);
         }
 
-        public static IAppBuilder UseForceSsl(this IAppBuilder appBuilder, int sslPort, IEnumerable<Regex> excludedPathPatterns)
+        public static IAppBuilder UseForceSsl(this IAppBuilder appBuilder, int sslPort, IEnumerable<string> excludedPaths)
         {
-            return appBuilder.Use<ForceSslMiddleware>(sslPort, excludedPathPatterns);
+            return appBuilder.Use<ForceSslMiddleware>(sslPort, excludedPaths);
         }
     }
 }

--- a/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
+++ b/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 using Moq;
@@ -59,34 +58,32 @@ namespace NuGet.Services.Owin.Tests
         }
 
         [Theory]
-        [InlineData("http://localhost/", new[] { "^/$" })]
-        [InlineData("http://localhost/search/diag", new[] { "^/$", "^/search/diag$" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "^/$", "^/somepath$" })]
-        public async Task RespectsExclusionList(string url, IEnumerable<string> exclusionPaths)
+        [InlineData("http://localhost/", new[] { "/" })]
+        [InlineData("http://localhost/search/diag", new[] { "/", "/search/diag" })]
+        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/somepath" })]
+        public async Task RespectsExclusionList(string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);
-            var exclusionList = exclusionPaths.Select(p => new Regex(p, RegexOptions.IgnoreCase));
             var context = CreateOwinContext("GET", uri);
             var next = CreateOwinMiddleware();
 
-            var middleware = new ForceSslMiddleware(next.Object, 443, exclusionList);
+            var middleware = new ForceSslMiddleware(next.Object, 443, excludedPaths);
             await middleware.Invoke(context);
 
             Assert.Equal((int)HttpStatusCode.OK, context.Response.StatusCode);
         }
 
         [Theory]
-        [InlineData("http://localhost/", new[] { "^/health$" })]
-        [InlineData("http://localhost/search/diag", new[] { "^/$" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "^/$", "^/someotherpath$" })]
-        public async Task RedirectsNotExludedUrls(string url, IEnumerable<string> exclusionPaths)
+        [InlineData("http://localhost/", new[] { "/health" })]
+        [InlineData("http://localhost/search/diag", new[] { "/" })]
+        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/someotherpath" })]
+        public async Task RedirectsNotExludedUrls(string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);
-            var exclusionList = exclusionPaths.Select(p => new Regex(p, RegexOptions.IgnoreCase));
             var context = CreateOwinContext("GET", uri);
             var next = CreateOwinMiddleware();
 
-            var middleware = new ForceSslMiddleware(next.Object, 443, exclusionList);
+            var middleware = new ForceSslMiddleware(next.Object, 443, excludedPaths);
             await middleware.Invoke(context);
 
             Assert.Equal((int)HttpStatusCode.Found, context.Response.StatusCode);

--- a/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
+++ b/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
@@ -59,8 +59,8 @@ namespace NuGet.Services.Owin.Tests
 
         [Theory]
         [InlineData("http://localhost/", new[] { "/" })]
-        [InlineData("http://localhost/search/diag", new[] { "/", "/search/diag" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/somepath" })]
+        [InlineData("http://localhost/Search/Diag", new[] { "/", "/search/diag" })]
+        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/SomePath" })]
         public async Task RespectsExclusionList(string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);
@@ -76,7 +76,7 @@ namespace NuGet.Services.Owin.Tests
         [Theory]
         [InlineData("http://localhost/", new[] { "/health" })]
         [InlineData("http://localhost/search/diag", new[] { "/" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/someotherpath" })]
+        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/SomeOtherPath" })]
         public async Task RedirectsNotExludedUrls(string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);

--- a/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
+++ b/tests/NuGet.Services.Owin.Tests/ForceSslMiddlewareFacts.cs
@@ -14,11 +14,36 @@ namespace NuGet.Services.Owin.Tests
 {
     public class ForceSslMiddlewareFacts
     {
+        public static IEnumerable<string> RedirectingMethods => new[]
+        {
+            "GET",
+            "HEAD",
+        };
+
+        public static IEnumerable<string> NonRedirectingMethods => new[]
+        {
+            "POST",
+            "PUT",
+            "DELETE",
+            "OPTIONS",
+            "TRACE",
+            "CONNECT",
+            "PATCH",
+        };
+
+        private static IEnumerable<int> PortsToTest => new[]
+        {
+            443,
+            1234
+        };
+
+        public static IEnumerable<object[]> AllowedMethodPorts =>
+            from method in RedirectingMethods
+            from port in PortsToTest
+            select new object[] { method, port };
+
         [Theory]
-        [InlineData("GET", 443)]
-        [InlineData("HEAD", 443)]
-        [InlineData("GET", 1234)]
-        [InlineData("HEAD", 1234)]
+        [MemberData(nameof(AllowedMethodPorts))]
         public async Task RedirectsGetHeadToHttps(string method, int sslPort)
         {
             var uri = new Uri("http://localhost:8080/somepath/somedocument?somequery=somevalue");
@@ -37,14 +62,12 @@ namespace NuGet.Services.Owin.Tests
             Assert.Equal(uri.PathAndQuery, targetUri.PathAndQuery);
         }
 
+        public static IEnumerable<object[]> ForbiddenMethodsToTest =>
+            from method in NonRedirectingMethods
+            select new object[] { method };
+
         [Theory]
-        [InlineData("POST")]
-        [InlineData("PUT")]
-        [InlineData("DELETE")]
-        [InlineData("OPTIONS")]
-        [InlineData("TRACE")]
-        [InlineData("CONNECT")]
-        [InlineData("PATCH")]
+        [MemberData(nameof(ForbiddenMethodsToTest))]
         public async Task ForbidsNonGetHead(string method)
         {
             var context = CreateOwinContext(method, new Uri("http://localhost"));
@@ -57,36 +80,78 @@ namespace NuGet.Services.Owin.Tests
             Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
         }
 
+        private static IEnumerable<(string url, string[] excludedPaths)> UrlsAndExcludesContainingUrls => new []
+        {
+            ("http://localhost/", new[] { "/" }),
+            ("http://localhost/Search/Diag", new[] { "/", "/search/diag" }),
+            ("http://localhost/somepath?something=somevalue", new[] { "/", "/SomePath" }),
+        };
+
+        public static IEnumerable<object[]> ExclusionsToTest =>
+            from method in RedirectingMethods.Concat(NonRedirectingMethods)
+            from urlExclusion in UrlsAndExcludesContainingUrls
+            select new object[] { method, urlExclusion.url, urlExclusion.excludedPaths };
+
         [Theory]
-        [InlineData("http://localhost/", new[] { "/" })]
-        [InlineData("http://localhost/Search/Diag", new[] { "/", "/search/diag" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/SomePath" })]
-        public async Task RespectsExclusionList(string url, IEnumerable<string> excludedPaths)
+        [MemberData(nameof(ExclusionsToTest))]
+        public async Task RespectsExclusionList(string method, string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);
-            var context = CreateOwinContext("GET", uri);
+            var context = CreateOwinContext(method, uri);
             var next = CreateOwinMiddleware();
 
             var middleware = new ForceSslMiddleware(next.Object, 443, excludedPaths);
             await middleware.Invoke(context);
 
+            next.Verify(n => n.Invoke(It.IsAny<IOwinContext>()), Times.Once());
             Assert.Equal((int)HttpStatusCode.OK, context.Response.StatusCode);
         }
 
+        private static IEnumerable<(string url, string[] excludedPaths)> UrlsAndExcludesNotContainingUrl => new[]
+        {
+            ("http://localhost/", new[] { "/health" }),
+            ("http://localhost/search/diag", new[] { "/" }),
+            ("http://localhost/somepath?something=somevalue", new[] { "/", "/SomeOtherPath" }),
+        };
+
+        public static IEnumerable<object[]> NonExclusionsToTest =>
+            from method in RedirectingMethods
+            from urlExclusion in UrlsAndExcludesNotContainingUrl
+            select new object[] { method, urlExclusion.url, urlExclusion.excludedPaths };
+
         [Theory]
-        [InlineData("http://localhost/", new[] { "/health" })]
-        [InlineData("http://localhost/search/diag", new[] { "/" })]
-        [InlineData("http://localhost/somepath?something=somevalue", new[] { "/", "/SomeOtherPath" })]
-        public async Task RedirectsNotExludedUrls(string url, IEnumerable<string> excludedPaths)
+        [MemberData(nameof(NonExclusionsToTest))]
+        public async Task RedirectsNotExcludedPaths(string method, string url, IEnumerable<string> excludedPaths)
         {
             var uri = new Uri(url);
-            var context = CreateOwinContext("GET", uri);
+            var context = CreateOwinContext(method, uri);
             var next = CreateOwinMiddleware();
 
             var middleware = new ForceSslMiddleware(next.Object, 443, excludedPaths);
             await middleware.Invoke(context);
 
+            next.Verify(n => n.Invoke(It.IsAny<IOwinContext>()), Times.Never());
             Assert.Equal((int)HttpStatusCode.Found, context.Response.StatusCode);
+        }
+
+        public static IEnumerable<object[]> NonGetHeadNonExclusionsToTest =>
+            from method in NonRedirectingMethods
+            from urlExclusion in UrlsAndExcludesNotContainingUrl
+            select new object[] { method, urlExclusion.url, urlExclusion.excludedPaths };
+
+        [Theory]
+        [MemberData(nameof(NonGetHeadNonExclusionsToTest))]
+        public async Task ForbidsNonGetHeadRequestsToNotExcludedPaths(string method, string url, IEnumerable<string> excludedPaths)
+        {
+            var uri = new Uri(url);
+            var context = CreateOwinContext(method, uri);
+            var next = CreateOwinMiddleware();
+
+            var middleware = new ForceSslMiddleware(next.Object, 443, excludedPaths);
+            await middleware.Invoke(context);
+
+            next.Verify(n => n.Invoke(It.IsAny<IOwinContext>()), Times.Never());
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
         }
 
         private static IOwinContext CreateOwinContext(string method, Uri uri)

--- a/tests/NuGet.Services.Owin.Tests/project.json
+++ b/tests/NuGet.Services.Owin.Tests/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "System.ValueTuple": "4.3.1",
     "Microsoft.Owin": "3.0.1",
     "Moq": "4.5.23",
     "xunit": "2.1.0",


### PR DESCRIPTION
Added the exclusion list to the ForceSslMiddleware.
Added tests for the change.