### PR TITLE
Fix NuGet version used by build scripts to 4.1.0

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -300,7 +300,7 @@ Function Install-NuGet {
     }
     
     Trace-Log 'Downloading latest prerelease of nuget.exe'
-    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $NuGetExe
+    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe -OutFile $NuGetExe
 }
 
 Function Configure-NuGetCredentials {


### PR DESCRIPTION
Fix the NuGet version used by our build to 4.1.0, instead of "latest-prerelease" which points to 4.0.0.