### PR TITLE
Add ETag support to Storage APIs

### DIFF
--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -10,9 +11,12 @@ namespace NuGet.Services.Storage
     public interface IStorage
     {
         Task Save(Uri resourceUri, StorageContent content, CancellationToken cancellationToken);
+        Task SaveIfETag(Uri resourceUri, StorageContent content, string eTag, CancellationToken cancellationToken);
         Task<StorageContent> Load(Uri resourceUri, CancellationToken cancellationToken);
         Task Delete(Uri resourceUri, CancellationToken cancellationToken);
+        Task DeleteIfETag(Uri resourceUri, string eTag, CancellationToken cancellationToken);
         Task<string> LoadString(Uri resourceUri, CancellationToken cancellationToken);
+        bool Exists(string fileName);
         Uri BaseAddress { get; }
         Uri ResolveUri(string relativeUri);
         Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -39,7 +39,7 @@ namespace NuGet.Services.Storage
         {
             SaveCount++;
 
-            TraceMethod(nameof(Save), resourceUri);
+            LogMethod(nameof(Save), resourceUri);
 
             try
             {
@@ -47,7 +47,7 @@ namespace NuGet.Services.Storage
             }
             catch (Exception e)
             {
-                throw TraceException(nameof(Save), resourceUri, e);
+                throw LogException(nameof(Save), resourceUri, e);
             }
         }
 
@@ -55,7 +55,7 @@ namespace NuGet.Services.Storage
         {
             SaveCount++;
 
-            TraceMethod(nameof(SaveIfETag), resourceUri);
+            LogMethod(nameof(SaveIfETag), resourceUri);
 
             try
             {
@@ -63,7 +63,7 @@ namespace NuGet.Services.Storage
             }
             catch (Exception e)
             {
-                throw TraceException(nameof(SaveIfETag), resourceUri, e);
+                throw LogException(nameof(SaveIfETag), resourceUri, e);
             }
         }
 
@@ -71,7 +71,7 @@ namespace NuGet.Services.Storage
         {
             LoadCount++;
 
-            TraceMethod(nameof(Load), resourceUri);
+            LogMethod(nameof(Load), resourceUri);
 
             try
             {
@@ -79,7 +79,7 @@ namespace NuGet.Services.Storage
             }
             catch (Exception e)
             {
-                throw TraceException(nameof(Load), resourceUri, e);
+                throw LogException(nameof(Load), resourceUri, e);
             }
         }
 
@@ -87,7 +87,7 @@ namespace NuGet.Services.Storage
         {
             DeleteCount++;
 
-            TraceMethod(nameof(Delete), resourceUri);
+            LogMethod(nameof(Delete), resourceUri);
 
             try
             {
@@ -111,7 +111,7 @@ namespace NuGet.Services.Storage
             }
             catch (Exception e)
             {
-                throw TraceException(nameof(Delete), resourceUri, e);
+                throw LogException(nameof(Delete), resourceUri, e);
             }
         }
 
@@ -119,7 +119,7 @@ namespace NuGet.Services.Storage
         {
             DeleteCount++;
 
-            TraceMethod(nameof(DeleteIfETag), resourceUri);
+            LogMethod(nameof(DeleteIfETag), resourceUri);
 
             try
             {
@@ -143,7 +143,7 @@ namespace NuGet.Services.Storage
             }
             catch (Exception e)
             {
-                throw TraceException(nameof(DeleteIfETag), resourceUri, e);
+                throw LogException(nameof(DeleteIfETag), resourceUri, e);
             }
         }
 
@@ -235,7 +235,7 @@ namespace NuGet.Services.Storage
             return new Uri(address);
         }
 
-        protected void TraceMethod(string method, Uri resourceUri)
+        protected void LogMethod(string method, Uri resourceUri)
         {
             if (Verbose)
             {
@@ -243,7 +243,7 @@ namespace NuGet.Services.Storage
             }
         }
 
-        protected Exception TraceException(string method, Uri resourceUri, Exception exception)
+        protected Exception LogException(string method, Uri resourceUri, Exception exception)
         {
             string message = String.Format("{Method} EXCEPTION: {0} {1}", method, resourceUri, exception.Message);
             Logger.LogError("{Method} EXCEPTION: {ResourceUri} {Exception}", method, resourceUri, exception);

--- a/src/NuGet.Services.Storage/StorageContent.cs
+++ b/src/NuGet.Services.Storage/StorageContent.cs
@@ -18,6 +18,12 @@ namespace NuGet.Services.Storage
             set;
         }
 
+        public string ETag
+        {
+            get;
+            set;
+        }
+
         public abstract Stream GetContentStream();
     }
 }

--- a/src/NuGet.Services.Storage/StorageListItem.cs
+++ b/src/NuGet.Services.Storage/StorageListItem.cs
@@ -7,14 +7,17 @@ namespace NuGet.Services.Storage
 {
     public class StorageListItem
     {
-        public Uri Uri { get; private set; }
+        public Uri Uri { get; set; }
 
-        public DateTime? LastModifiedUtc { get; private set; }
+        public DateTime? LastModifiedUtc { get; set; }
 
-        public StorageListItem(Uri uri, DateTime? lastModifiedUtc)
+        public string ETag { get; set; }
+
+        public StorageListItem(Uri uri, DateTime? lastModifiedUtc, string eTag)
         {
             Uri = uri;
             LastModifiedUtc = lastModifiedUtc;
+            ETag = eTag;
         }
     }
 }


### PR DESCRIPTION
Currently there's no way to do optimistic concurrency with our storage calls.

The V3 monitoring job uses the ETag support to allow multiple `MonitoringProcessor`s to be running at once.