### PR TITLE
For storage APIs, use interfaces whenever possible

### DIFF
--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -11,10 +11,10 @@ namespace NuGet.Services.Cursor
     public class DurableCursor : ReadWriteCursor<DateTimeOffset>
     {
         Uri _address;
-        Storage.Storage _storage;
+        IStorage _storage;
         DateTimeOffset _defaultValue;
 
-        public DurableCursor(Uri address, Storage.Storage storage, DateTimeOffset defaultValue)
+        public DurableCursor(Uri address, IStorage storage, DateTimeOffset defaultValue)
         {
             _address = address ?? throw new ArgumentNullException(nameof(address));
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));

--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -18,11 +18,11 @@ namespace NuGet.Services.Storage
             Uri secondaryResourceUri, 
             StorageContent content);
 
-        private readonly Storage _primaryStorage;
-        private readonly Storage[] _secondaryStorage;
+        private readonly IStorage _primaryStorage;
+        private readonly IStorage[] _secondaryStorage;
         private readonly WriteSecondaryStorageContentInterceptor _writeSecondaryStorageContentInterceptor;
         
-        public AggregateStorage(Uri baseAddress, Storage primaryStorage, Storage[] secondaryStorage,
+        public AggregateStorage(Uri baseAddress, IStorage primaryStorage, IStorage[] secondaryStorage,
             WriteSecondaryStorageContentInterceptor writeSecondaryStorageContentInterceptor,
             ILogger<AggregateStorage> logger)
             : base(baseAddress, logger)

--- a/src/NuGet.Services.Storage/AggregateStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AggregateStorageFactory.cs
@@ -12,12 +12,12 @@ namespace NuGet.Services.Storage
         private readonly AggregateStorage.WriteSecondaryStorageContentInterceptor _writeSecondaryStorageContentInterceptor;
         private readonly ILogger<AggregateStorage> _aggregateStorageLogger;
 
-        public AggregateStorageFactory(StorageFactory primaryStorageFactory, ICollection<StorageFactory> secondaryStorageFactories, ILogger<AggregateStorage> aggregateStorageLogger)
+        public AggregateStorageFactory(IStorageFactory primaryStorageFactory, ICollection<IStorageFactory> secondaryStorageFactories, ILogger<AggregateStorage> aggregateStorageLogger)
             : this(primaryStorageFactory, secondaryStorageFactories, null, aggregateStorageLogger)
         {
         }
 
-        public AggregateStorageFactory(StorageFactory primaryStorageFactory, ICollection<StorageFactory> secondaryStorageFactories,
+        public AggregateStorageFactory(IStorageFactory primaryStorageFactory, ICollection<IStorageFactory> secondaryStorageFactories,
             AggregateStorage.WriteSecondaryStorageContentInterceptor writeSecondaryStorageContentInterceptor,
             ILogger<AggregateStorage> aggregateStorageLogger)
         { 
@@ -29,7 +29,7 @@ namespace NuGet.Services.Storage
             BaseAddress = PrimaryStorageFactory.BaseAddress;
         }
 
-        public override Storage Create(string name = null)
+        public override IStorage Create(string name = null)
         {
             var primaryStorage = PrimaryStorageFactory.Create(name);
             var secondaryStorage = SecondaryStorageFactories.Select(f => f.Create(name)).ToArray();
@@ -42,7 +42,7 @@ namespace NuGet.Services.Storage
                 _aggregateStorageLogger);
         }
 
-        public StorageFactory PrimaryStorageFactory { get; }
-        public IEnumerable<StorageFactory> SecondaryStorageFactories { get; }
+        public IStorageFactory PrimaryStorageFactory { get; }
+        public IEnumerable<IStorageFactory> SecondaryStorageFactories { get; }
     }
 }

--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -58,7 +58,7 @@ namespace NuGet.Services.Storage
             set;
         }
 
-        public override Storage Create(string name = null)
+        public override IStorage Create(string name = null)
         {
             string path = (_path == null) ? name : _path + name;
 

--- a/src/NuGet.Services.Storage/FileStorageFactory.cs
+++ b/src/NuGet.Services.Storage/FileStorageFactory.cs
@@ -18,7 +18,7 @@ namespace NuGet.Services.Storage
             _fileStorageLogger = fileStorageLogger;
         }
 
-        public override Storage Create(string name = null)
+        public override IStorage Create(string name = null)
         {
             string fileSystemPath = (name == null) ? _path.Trim('\\') : _path + name;
             string uriPath = name ?? string.Empty;

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -15,6 +15,7 @@ namespace NuGet.Services.Storage
         Task<string> LoadString(Uri resourceUri, CancellationToken cancellationToken);
         Uri BaseAddress { get; }
         Uri ResolveUri(string relativeUri);
+        bool Exists(string fileName);
         Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Services.Storage/IStorageFactory.cs
+++ b/src/NuGet.Services.Storage/IStorageFactory.cs
@@ -6,7 +6,7 @@ namespace NuGet.Services.Storage
 {
     public interface IStorageFactory
     {
-        Storage Create(string name = null);
+        IStorage Create(string name = null);
         Uri BaseAddress { get; }
     }
 }

--- a/src/NuGet.Services.Storage/StorageFactory.cs
+++ b/src/NuGet.Services.Storage/StorageFactory.cs
@@ -6,7 +6,7 @@ namespace NuGet.Services.Storage
 {
     public abstract class StorageFactory : IStorageFactory
     {
-        public abstract Storage Create(string name = null);
+        public abstract IStorage Create(string name = null);
 
         public Uri BaseAddress { get; protected set; }
 

--- a/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
+++ b/tests/NuGet.Services.Cursor.Tests/DurableCursorFacts.cs
@@ -88,7 +88,7 @@ namespace NuGet.Services.Cursor.Tests
         {
             var loggerMock = new Mock<ILogger<Storage.Storage>>();
 
-            return new Mock<Storage.Storage>(MockBehavior.Strict, new Uri("http://localhost/"), loggerMock.Object);
+            return new Mock<Storage.Storage>(new Uri("http://localhost/"), loggerMock.Object) { CallBase = true };
         }
     }
 }


### PR DESCRIPTION
For whatever reason, we were declaring storage interfaces (`IStorage`, `IStorageFactory`) but not using them everywhere and instead using the base implementation (`Storage`, `StorageFactory`). This PR fixes all instances of this.

It also adds `Exists` to `IStorage`, because it seemed ridiculous not to have it when every subclass implements it.