### PR TITLE
[Package Signing] Added a Scoped Service Bus Message Handler

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27005.2
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8415FED7-1BED-4227-8B4F-BB7C24E041CD}"
 EndProject
@@ -49,6 +49,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Contracts.Tests", "tests\NuGet.Services.Contracts.Tests\NuGet.Services.Contracts.Tests.csproj", "{79F72C83-E94D-4D04-B904-5A4DA161168E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.ServiceBus.Tests", "tests\NuGet.Services.ServiceBus.Tests\NuGet.Services.ServiceBus.Tests.csproj", "{FF5CA51A-CD6A-463F-AE9A-5737FF0FCFA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.KeyVault.Tests", "tests\NuGet.Services.KeyVault.Tests\NuGet.Services.KeyVault.Tests.csproj", "{BA1FB5F1-8F6B-4558-862B-F47C3995B06A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -132,6 +134,10 @@ Global
 		{FF5CA51A-CD6A-463F-AE9A-5737FF0FCFA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF5CA51A-CD6A-463F-AE9A-5737FF0FCFA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF5CA51A-CD6A-463F-AE9A-5737FF0FCFA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +162,7 @@ Global
 		{E29F54DF-DFB8-4E27-940D-21ECCB9B6FC1} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{79F72C83-E94D-4D04-B904-5A4DA161168E} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{FF5CA51A-CD6A-463F-AE9A-5737FF0FCFA7} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
+		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AA413DB0-5475-4B5D-A3AF-6323DA8D538B}

--- a/src/NuGet.Services.KeyVault/CachingSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/CachingSecretReader.cs
@@ -25,7 +25,12 @@ namespace NuGet.Services.KeyVault
 
         public async Task<string> GetSecretAsync(string secretName)
         {
-            // If the cache contains the secret and it is not expired, returned the cached value.
+            if (string.IsNullOrEmpty(secretName))
+            {
+                throw new ArgumentException("Null or empty secret name", nameof(secretName));
+            }
+
+            // If the cache contains the secret and it is not expired, return the cached value.
             if (_cache.TryGetValue(secretName, out CachedSecret result))
             {
                 if (!IsSecretOutdated(result))
@@ -51,7 +56,7 @@ namespace NuGet.Services.KeyVault
         /// <summary>
         /// A cached secret.
         /// </summary>
-        private struct CachedSecret
+        private class CachedSecret
         {
             /// <summary>
             /// The value of the cached secret.

--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -46,6 +46,7 @@
     <Compile Include="IMessageHandler.cs" />
     <Compile Include="ISubscriptionProcessor.cs" />
     <Compile Include="OnMessageOptionsWrapper.cs" />
+    <Compile Include="ScopedMessageHandler.cs" />
     <Compile Include="SubscriptionProcessor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />

--- a/src/NuGet.Services.ServiceBus/ScopedMessageHandler.cs
+++ b/src/NuGet.Services.ServiceBus/ScopedMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +18,11 @@ namespace NuGet.Services.ServiceBus
         /// The factory used to create independent dependency injection scopes for each message.
         /// </summary>
         private readonly IServiceScopeFactory _scopeFactory;
+
+        public ScopedMessageHandler(IServiceScopeFactory scopeFactory)
+        {
+            _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        }
 
         /// <summary>
         /// Handle the message in its own dependency injection scope.

--- a/src/NuGet.Services.ServiceBus/ScopedMessageHandler.cs
+++ b/src/NuGet.Services.ServiceBus/ScopedMessageHandler.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NuGet.Services.ServiceBus
+{
+    /// <summary>
+    /// Handles messages received by a <see cref="ISubscriptionProcessor{TMessage}"/>.
+    /// Each message will be handled within its own dependency injection scope.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of messages this handler handles.</typeparam>
+    public class ScopedMessageHandler<TMessage>
+    {
+        /// <summary>
+        /// The factory used to create independent dependency injection scopes for each message.
+        /// </summary>
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        /// <summary>
+        /// Handle the message in its own dependency injection scope.
+        /// </summary>
+        /// <param name="message">The received message.</param>
+        /// <returns>Whether the message has been handled. If false, the message will be requeued to be handled again later.</returns>
+        public async Task<bool> HandleAsync(TMessage message)
+        {
+            // Create a new scope for this message.
+            using (var scope = _scopeFactory.CreateScope())
+            {
+                // Resolve a new message handler for the newly created scope and let it handle the message.
+                return await ResolveMessageHandler(scope).HandleAsync(message);
+            }
+        }
+
+        /// <summary>
+        /// Resolve the message handler given a specific dependency injection scope.
+        /// </summary>
+        /// <param name="scope">The dependency injection scope that should be used to resolve services.</param>
+        /// <returns>The resolved message handler service from the given scope.</returns>
+        private IMessageHandler<TMessage> ResolveMessageHandler(IServiceScope scope)
+        {
+            return scope.ServiceProvider.GetRequiredService<IMessageHandler<TMessage>>();
+        }
+    }
+}

--- a/src/NuGet.Services.ServiceBus/project.json
+++ b/src/NuGet.Services.ServiceBus/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.1",
     "Microsoft.Extensions.Logging": "1.1.2",
     "Newtonsoft.Json": "9.0.1",
     "WindowsAzure.ServiceBus": "4.1.3"

--- a/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
+++ b/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="BrokeredMessageWrapperFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BrokeredMessageSerializerFacts.cs" />
+    <Compile Include="ScopedMessageHandlerFacts.cs" />
     <Compile Include="SubscriptionProcessorFacts.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.ServiceBus.Tests/ScopedMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/ScopedMessageHandlerFacts.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.ServiceBus.Tests
+{
+    public class ScopedMessageHandlerFacts
+    {
+        [Fact]
+        public async Task CreatesMessageHandlerUsingScope()
+        {
+            // Arrange
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var scopeMock = new Mock<IServiceScope>();
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            var handlerMock = new Mock<IMessageHandler<object>>();
+
+            scopeFactoryMock
+                .Setup(f => f.CreateScope())
+                .Returns(scopeMock.Object);
+
+            scopeMock
+                .SetupGet(s => s.ServiceProvider)
+                .Returns(serviceProviderMock.Object);
+
+            serviceProviderMock
+                .Setup(p => p.GetService(typeof(IMessageHandler<object>)))
+                .Returns(handlerMock.Object);
+
+            var target = new ScopedMessageHandler<object>(scopeFactoryMock.Object);
+
+            // Act - send two empty messages.
+            await target.HandleAsync(new object());
+            await target.HandleAsync(new object());
+
+            // Assert
+            scopeFactoryMock.Verify(f => f.CreateScope(), Times.Exactly(2));
+            serviceProviderMock.Verify(p => p.GetService(typeof(IMessageHandler<object>)), Times.Exactly(2));
+            handlerMock.Verify(h => h.HandleAsync(It.IsAny<object>()), Times.Exactly(2));
+        }
+    }
+}


### PR DESCRIPTION
Often times, Service Bus message handlers will need to use some sort of Entity Framework context. This requires that the handlers' callbacks are executed within their own dependency injection scope. This change creates a new generic Service Bus message handler `ScopedMessageHandler` that, upon receiving a message, creates a new dependency injection scope.

This change also makes `CachingSecretReader` thread-safe, as otherwise, the `ScopedMessageHandler` would need a lock.