### PR TITLE
Download nuget.exe v4.4.1

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -300,7 +300,7 @@ Function Install-NuGet {
     }
     
     Trace-Log 'Downloading latest prerelease of nuget.exe'
-    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe -OutFile $NuGetExe
+    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $NuGetExe
 }
 
 Function Configure-NuGetCredentials {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -300,7 +300,7 @@ Function Install-NuGet {
     }
     
     Trace-Log 'Downloading latest prerelease of nuget.exe'
-    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $NuGetExe
+    wget -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v4.4.1/nuget.exe -OutFile $NuGetExe
 }
 
 Function Configure-NuGetCredentials {


### PR DESCRIPTION
In the windows os with Simplified Chinese culture, there will be some strange errors when packaging with nuget.exe 4.1.0.
But packaging with the latest version nuget.exe, the errors disappeared. 