### PR TITLE
Expose Exists API on IStorage + add Async overload

### DIFF
--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -86,6 +86,11 @@ namespace NuGet.Services.Storage
             return _primaryStorage.Exists(fileName);
         }
 
+        public override Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            return _primaryStorage.ExistsAsync(fileName, cancellationToken);
+        }
+
         public override Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
         {
             return _primaryStorage.List(cancellationToken);

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -78,6 +78,24 @@ namespace NuGet.Services.Storage
             return false;
         }
 
+        public override async Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            Uri packageRegistrationUri = ResolveUri(fileName);
+            string blobName = GetName(packageRegistrationUri);
+
+            CloudBlockBlob blob = _directory.GetBlockBlobReference(blobName);
+
+            if (await blob.ExistsAsync(cancellationToken))
+            {
+                return true;
+            }
+            if (Verbose)
+            {
+                _logger.LogInformation("The blob {BlobUri} does not exist.", packageRegistrationUri);
+            }
+            return false;
+        }
+
         public override async Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
         {
             var files = await _directory.ListBlobsAsync(cancellationToken);

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -62,10 +62,10 @@ namespace NuGet.Services.Storage
         //Blob exists
         public override bool Exists(string fileName)
         {
-            Uri packageRegistrationUri = ResolveUri(fileName);
-            string blobName = GetName(packageRegistrationUri);
+            var packageRegistrationUri = ResolveUri(fileName);
+            var blobName = GetName(packageRegistrationUri);
 
-            CloudBlockBlob blob = _directory.GetBlockBlobReference(blobName);
+            var blob = _directory.GetBlockBlobReference(blobName);
 
             if (blob.Exists())
             {
@@ -80,10 +80,10 @@ namespace NuGet.Services.Storage
 
         public override async Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
         {
-            Uri packageRegistrationUri = ResolveUri(fileName);
-            string blobName = GetName(packageRegistrationUri);
+            var packageRegistrationUri = ResolveUri(fileName);
+            var blobName = GetName(packageRegistrationUri);
 
-            CloudBlockBlob blob = _directory.GetBlockBlobReference(blobName);
+            var blob = _directory.GetBlockBlobReference(blobName);
 
             if (await blob.ExistsAsync(cancellationToken))
             {

--- a/src/NuGet.Services.Storage/FileStorage.cs
+++ b/src/NuGet.Services.Storage/FileStorage.cs
@@ -35,6 +35,11 @@ namespace NuGet.Services.Storage
             return File.Exists(fileName);
         }
 
+        public override Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Exists(fileName));
+        }
+
         public override Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
         {
             DirectoryInfo directoryInfo = new DirectoryInfo(Path);

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -9,6 +10,8 @@ namespace NuGet.Services.Storage
 {
     public interface IStorage
     {
+        bool Exists(string fileName);
+        Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
         Task Save(Uri resourceUri, StorageContent content, CancellationToken cancellationToken);
         Task<StorageContent> Load(Uri resourceUri, CancellationToken cancellationToken);
         Task Delete(Uri resourceUri, CancellationToken cancellationToken);

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -120,6 +120,7 @@ namespace NuGet.Services.Storage
 
         public Uri BaseAddress { get; protected set; }
         public abstract bool Exists(string fileName);
+        public abstract Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
         public abstract Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);
 
         public bool Verbose


### PR DESCRIPTION
All of the concrete implementations of `IStorage` already implemented the `Exists(string)` method, but it was not exposed on the interface. This PR adds it to the interface, and adds an async overload (which is useful when consuming a storage abstraction that supports async I/O).

Will be used by `ICertificateStore` implementation in validation job.