### PR TITLE
Round trip bytes properly and allow no overwrite in Storage abstraction

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -54,6 +54,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.Issues.Tests", "tests\NuGet.Services.Validation.Issues.Tests\NuGet.Services.Validation.Issues.Tests.csproj", "{E7412F21-169C-4823-AB2C-F6EE20E6411E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Storage.Tests", "tests\NuGet.Services.Storage.Tests\NuGet.Services.Storage.Tests.csproj", "{CEFBA9D0-2B2B-4691-B661-2C8050245C92}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -144,6 +146,10 @@ Global
 		{E7412F21-169C-4823-AB2C-F6EE20E6411E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7412F21-169C-4823-AB2C-F6EE20E6411E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7412F21-169C-4823-AB2C-F6EE20E6411E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEFBA9D0-2B2B-4691-B661-2C8050245C92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CEFBA9D0-2B2B-4691-B661-2C8050245C92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEFBA9D0-2B2B-4691-B661-2C8050245C92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CEFBA9D0-2B2B-4691-B661-2C8050245C92}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,6 +176,7 @@ Global
 		{BA1FB5F1-8F6B-4558-862B-F47C3995B06A} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{4F497FBD-91CF-4FA5-B948-4375BEBFD2C8} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{E7412F21-169C-4823-AB2C-F6EE20E6411E} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
+		{CEFBA9D0-2B2B-4691-B661-2C8050245C92} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AA413DB0-5475-4B5D-A3AF-6323DA8D538B}

--- a/src/NuGet.Services.Cursor/DurableCursor.cs
+++ b/src/NuGet.Services.Cursor/DurableCursor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace NuGet.Services.Cursor
         {
             JObject obj = new JObject { { "value", Value.ToString("O") } };
             StorageContent content = new StringStorageContent(obj.ToString(), "application/json", "no-store");
-            await _storage.Save(_address, content, cancellationToken);
+            await _storage.Save(_address, content, overwrite: true, cancellationToken: cancellationToken);
         }
 
         public override async Task Load(CancellationToken cancellationToken)

--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -34,10 +34,10 @@ namespace NuGet.Services.Storage
             BaseAddress = _primaryStorage.BaseAddress;
         }
         
-        protected override Task OnSave(Uri resourceUri, StorageContent content, CancellationToken cancellationToken)
+        protected override Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
-            tasks.Add(_primaryStorage.Save(resourceUri, content, cancellationToken));
+            tasks.Add(_primaryStorage.Save(resourceUri, content, overwrite, cancellationToken));
 
             foreach (var storage in _secondaryStorage)
             {
@@ -54,7 +54,7 @@ namespace NuGet.Services.Storage
                         secondaryResourceUri, content);
                 }
 
-                tasks.Add(storage.Save(secondaryResourceUri, secondaryContent, cancellationToken));
+                tasks.Add(storage.Save(secondaryResourceUri, secondaryContent, overwrite, cancellationToken));
             }
 
             return Task.WhenAll(tasks);

--- a/src/NuGet.Services.Storage/FileStorage.cs
+++ b/src/NuGet.Services.Storage/FileStorage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -58,7 +59,7 @@ namespace NuGet.Services.Storage
 
         //  save
 
-        protected override async Task OnSave(Uri resourceUri, StorageContent content, CancellationToken cancellationToken)
+        protected override async Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             SaveCount++;
 
@@ -91,7 +92,9 @@ namespace NuGet.Services.Storage
                 }
             }
 
-            using (FileStream stream = File.Create(path + name))
+            var fileMode = overwrite ? FileMode.Create : FileMode.CreateNew;
+
+            using (FileStream stream = new FileStream(path + name, fileMode))
             {
                 await content.GetContentStream().CopyToAsync(stream,4096, cancellationToken);
             }

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.Storage
     {
         bool Exists(string fileName);
         Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
-        Task Save(Uri resourceUri, StorageContent content, CancellationToken cancellationToken);
+        Task Save(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken);
         Task<StorageContent> Load(Uri resourceUri, CancellationToken cancellationToken);
         Task Delete(Uri resourceUri, CancellationToken cancellationToken);
         Task<string> LoadString(Uri resourceUri, CancellationToken cancellationToken);

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,11 +28,11 @@ namespace NuGet.Services.Storage
             return BaseAddress.ToString();
         }
 
-        protected abstract Task OnSave(Uri resourceUri, StorageContent content, CancellationToken cancellationToken);
+        protected abstract Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken);
         protected abstract Task<StorageContent> OnLoad(Uri resourceUri, CancellationToken cancellationToken);
         protected abstract Task OnDelete(Uri resourceUri, CancellationToken cancellationToken);
 
-        public async Task Save(Uri resourceUri, StorageContent content, CancellationToken cancellationToken)
+        public async Task Save(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             SaveCount++;
 
@@ -39,7 +40,7 @@ namespace NuGet.Services.Storage
 
             try
             {
-                await OnSave(resourceUri, content, cancellationToken);
+                await OnSave(resourceUri, content, overwrite, cancellationToken);
             }
             catch (Exception e)
             {

--- a/tests/NuGet.Services.Storage.Tests/AzureStorageFacts.cs
+++ b/tests/NuGet.Services.Storage.Tests/AzureStorageFacts.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.Storage.Tests
+{
+    public class AzureStorageFacts
+    {
+        private const string NoEmulator = "The Azure Storage emulator is not running on the CI.";
+        private const string ContainerName = "test";
+        private static readonly Uri BaseAddress = new Uri("http://example/dir/");
+        private const string BlobName = "blob.txt";
+        private const string InitialContent = "pre-existing content";
+
+        public class Load : BaseFacts
+        {
+            [Theory(Skip = NoEmulator)]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task ProperlyRoundTripsBytes(bool compressContent)
+            {
+                // Arrange
+                await CreateBlobAsync(_dirPath, BlobName);
+
+                _target.CompressContent = compressContent;
+
+                var inputBytes = new byte[] { 0x80 };
+                var inputContent = new StreamStorageContent(new MemoryStream(inputBytes));
+
+                await _target.Save(_resourceUri, inputContent, overwrite: true, cancellationToken: CancellationToken.None);
+
+                // Act
+                var response = await _target.Load(_resourceUri, CancellationToken.None);
+
+                // Assert
+                using (var stream = response.GetContentStream())
+                {
+                    var buffer = new MemoryStream();
+                    await stream.CopyToAsync(buffer);
+                    var outputBytes = buffer.ToArray();
+                    Assert.Equal(inputBytes, outputBytes);
+                }
+            }
+        }
+
+        public class Save : BaseFacts
+        {
+            [Fact(Skip = NoEmulator)]
+            public async Task ThrowsWhenOverwritesAreNotDesired()
+            {
+                // Arrange
+                await CreateBlobAsync(_dirPath, BlobName);
+
+                var content = new StringStorageContent("new content");
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<Exception>(
+                    () => _target.Save(_resourceUri, content, overwrite: false, cancellationToken: CancellationToken.None));
+
+                Assert.Contains("The remote server returned an error: (409) Conflict.", exception.Message);
+
+                var currentContent = await _target.LoadString(_resourceUri, CancellationToken.None);
+                Assert.Equal(InitialContent, currentContent);
+            }
+
+            [Fact(Skip = NoEmulator)]
+            public async Task AllowsOverwriteWhenDesired()
+            {
+                // Arrange
+                await CreateBlobAsync(_dirPath, BlobName);
+
+                var inputContent = new StringStorageContent("new content");
+
+                // Act
+                await _target.Save(_resourceUri, inputContent, overwrite: true, cancellationToken: CancellationToken.None);
+                
+                // Assert
+                var currentContent = await _target.LoadString(_resourceUri, CancellationToken.None);
+                Assert.Equal(inputContent.Content, currentContent);
+            }
+        }
+
+        public class BaseFacts
+        {
+            protected readonly string _dirPath;
+            protected readonly AzureStorage _target;
+            protected readonly Uri _resourceUri;
+
+            public BaseFacts()
+            {
+                _dirPath = Guid.NewGuid().ToString();
+                _target = new AzureStorage(
+                    CloudStorageAccount.DevelopmentStorageAccount,
+                    ContainerName,
+                    _dirPath,
+                    BaseAddress,
+                    new Mock<ILogger<AzureStorage>>().Object);
+
+                _resourceUri = new Uri(BaseAddress, BlobName);
+            }
+        }
+
+        private static async Task CreateBlobAsync(string dirPath, string filePath)
+        {
+            await CreateBlobAsync(dirPath, filePath, Encoding.UTF8.GetBytes(InitialContent));
+        }
+
+        private static async Task CreateBlobAsync(string dirPath, string filePath, byte[] content)
+        {
+            var account = CloudStorageAccount.DevelopmentStorageAccount;
+            var client = account.CreateCloudBlobClient();
+            var container = client.GetContainerReference(ContainerName);
+            var directory = container.GetDirectoryReference(dirPath);
+            var blob = directory.GetBlockBlobReference(filePath);
+
+            await blob.UploadFromByteArrayAsync(content, 0, content.Length);
+        }
+    }
+}

--- a/tests/NuGet.Services.Storage.Tests/NuGet.Services.Storage.Tests.csproj
+++ b/tests/NuGet.Services.Storage.Tests/NuGet.Services.Storage.Tests.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CEFBA9D0-2B2B-4691-B661-2C8050245C92}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.Storage</RootNamespace>
+    <AssemblyName>NuGet.Services.Storage.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AzureStorageFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Moq">
+      <Version>4.5.23</Version>
+    </PackageReference>
+    <PackageReference Include="WindowsAzure.Storage">
+      <Version>7.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.1.0</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.Storage\NuGet.Services.Storage.csproj">
+      <Project>{aed43955-2676-48ec-a27e-6965008d4b3b}</Project>
+      <Name>NuGet.Services.Storage</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/NuGet.Services.Storage.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NuGet.Services.Storage.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.Services.Storage.Tests")]
+[assembly: ComVisible(false)]
+[assembly: Guid("cefba9d0-2b2b-4691-b661-2c8050245c92")]


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5175.

Tests are skipped because they need Azure Storage emulator to run them.

This PR is currently blocking https://github.com/NuGet/NuGet.Jobs/pull/280.