### PR TITLE
Better exception logging in SubscriptionProcessor.

### DIFF
--- a/src/NuGet.Services.ServiceBus/Event.cs
+++ b/src/NuGet.Services.ServiceBus/Event.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Services.ServiceBus
+{
+    public static class Event
+    {
+        // should be sufficiently different from other event id's, but no strict
+        // requirement, numbers mean nothing so far
+        private const int EventIdBase = 600; 
+
+        public static EventId SubscriptionMessageHandlerException = new EventId(EventIdBase + 1, "Subscription event handler threw exception");
+    }
+}

--- a/src/NuGet.Services.ServiceBus/Event.cs
+++ b/src/NuGet.Services.ServiceBus/Event.cs
@@ -9,8 +9,11 @@ namespace NuGet.Services.ServiceBus
     {
         // should be sufficiently different from other event id's, but no strict
         // requirement, numbers mean nothing so far
-        private const int EventIdBase = 600; 
+        private const int EventIdBase = 600;
+        private const int SubscriptionMessageHandlerExceptionEventId = EventIdBase + 1;
 
-        public static EventId SubscriptionMessageHandlerException = new EventId(EventIdBase + 1, "Subscription event handler threw exception");
+        public static EventId SubscriptionMessageHandlerException = new EventId(
+            SubscriptionMessageHandlerExceptionEventId,
+            "Subscription event handler threw exception");
     }
 }

--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Include="BrokeredMessageSerializer.cs" />
     <Compile Include="BrokeredMessageWrapper.cs" />
+    <Compile Include="Event.cs" />
     <Compile Include="IBrokeredMessageSerializer.cs" />
     <Compile Include="IMessageHandler.cs" />
     <Compile Include="ISubscriptionProcessor.cs" />

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -74,7 +74,7 @@ namespace NuGet.Services.ServiceBus
             }
             catch (Exception e)
             {
-                _logger.LogError("Requeueing message as it was unsuccessfully processed due to exception: {Exception}", e);
+                _logger.LogError(Event.SubscriptionMessageHandlerException, e, "Requeueing message as it was unsuccessfully processed due to exception");
                 throw;
             }
             finally


### PR DESCRIPTION
Previously exception was logged in the message body converting the exception object to string, that caused truncation and loss of full stack trace.
By logging it this way we'll have structured exception information in AI entry.