### PR TITLE
When an issue has bad data, deserialize the issue as UnknownIssue

### DIFF
--- a/src/NuGet.Services.Validation.Issues/ClientSigningVerificationFailure.cs
+++ b/src/NuGet.Services.Validation.Issues/ClientSigningVerificationFailure.cs
@@ -20,10 +20,10 @@ namespace NuGet.Services.Validation.Issues
 
         public override ValidationIssueCode IssueCode => ValidationIssueCode.ClientSigningVerificationFailure;
 
-        [JsonProperty("c")]
+        [JsonProperty("c", Required = Required.Always)]
         public string ClientCode { get; }
         
-        [JsonProperty("m")]
+        [JsonProperty("m", Required = Required.Always)]
         public string ClientMessage { get; }
 
         public override string GetMessage() => _codeAndMessage;

--- a/src/NuGet.Services.Validation.Issues/ObsoleteTestingIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ObsoleteTestingIssue.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Newtonsoft.Json;
 
 namespace NuGet.Services.Validation.Issues
 {
@@ -21,8 +22,10 @@ namespace NuGet.Services.Validation.Issues
         public override ValidationIssueCode IssueCode => ValidationIssueCode.ObsoleteTesting;
 #pragma warning restore 618
 
+        [JsonProperty(Required = Required.AllowNull)]
         public string A { get; set; }
 
+        [JsonProperty(Required = Required.AllowNull)]
         public int B { get; set; }
 
         public override string GetMessage() => string.Empty;

--- a/src/NuGet.Services.Validation.Issues/SignedPackageMustHaveOneSignature.cs
+++ b/src/NuGet.Services.Validation.Issues/SignedPackageMustHaveOneSignature.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.Validation.Issues
 
         public override ValidationIssueCode IssueCode => ValidationIssueCode.SignedPackageMustHaveOneSignature;
 
-        [JsonProperty("c")]
+        [JsonProperty("c", Required = Required.Always)]
         public int Count { get; }
 
         public override string GetMessage() => string.Format(Strings.SignedPackageMustHaveOneSignatureMessage, Count);

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -35,7 +35,18 @@ namespace NuGet.Services.Validation.Issues
                 return new UnknownIssue();
             }
 
-            return (ValidationIssue)JsonConvert.DeserializeObject(data, deserializationType);
+            try
+            {
+                var issue = JsonConvert.DeserializeObject(data, deserializationType) as ValidationIssue;
+
+                /// <see cref="JsonConvert.DeserializeObject(string, Type)"/> can return null in some cases (for
+                /// example if the input string is empty).
+                return issue ?? new UnknownIssue();
+            }
+            catch (Exception)
+            {
+                return new UnknownIssue();
+            }
         }
 
         /// <summary>

--- a/tests/NuGet.Services.Validation.Issues.Tests/Strings.Designer.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/Strings.Designer.cs
@@ -79,15 +79,6 @@ namespace NuGet.Services.Validation.Issues.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hello this is dog.
-        /// </summary>
-        internal static string InvalidJson {
-            get {
-                return ResourceManager.GetString("InvalidJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {&quot;A&quot;:&quot;Hello&quot;,&quot;B&quot;:123}.
         /// </summary>
         internal static string ObsoleteTestingIssueJson {
@@ -102,6 +93,15 @@ namespace NuGet.Services.Validation.Issues.Tests {
         internal static string SignedPackageMustHaveOneSignatureIssueJson {
             get {
                 return ResourceManager.GetString("SignedPackageMustHaveOneSignatureIssueJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;c&quot;:1}.
+        /// </summary>
+        internal static string SignedPackageMustHaveOneSignatureIssueJsonInvalidCount {
+            get {
+                return ResourceManager.GetString("SignedPackageMustHaveOneSignatureIssueJsonInvalidCount", resourceCulture);
             }
         }
     }

--- a/tests/NuGet.Services.Validation.Issues.Tests/Strings.resx
+++ b/tests/NuGet.Services.Validation.Issues.Tests/Strings.resx
@@ -123,13 +123,13 @@
   <data name="EmptyJson" xml:space="preserve">
     <value>{}</value>
   </data>
-  <data name="InvalidJson" xml:space="preserve">
-    <value>Hello this is dog</value>
-  </data>
   <data name="ObsoleteTestingIssueJson" xml:space="preserve">
     <value>{"A":"Hello","B":123}</value>
   </data>
   <data name="SignedPackageMustHaveOneSignatureIssueJson" xml:space="preserve">
     <value>{"c":2}</value>
+  </data>
+  <data name="SignedPackageMustHaveOneSignatureIssueJsonInvalidCount" xml:space="preserve">
+    <value>{"c":1}</value>
   </data>
 </root>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/5265.

The goal here is to show a generic error message to users in the gallery when there is some deserialization problem.