### PR TITLE
[Service Bus] Add timeout to shutdown

### DIFF
--- a/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.ServiceBus
@@ -29,7 +30,9 @@ namespace NuGet.Services.ServiceBus
         /// The <see cref="NumberOfMessagesInProgress"/> property should be polled to determine when all
         /// messages have been completed.
         /// </remarks>
-        /// <returns>A task that completes when the message handler has been deregistered.</returns>
-        Task StartShutdownAsync();
+        /// <param name="timeout">The maximum amount of time this method may take to start the shutdown.</param>
+        /// <returns>A task that completes with as <see cref="true"/> when the message handler has been
+        /// deregistered, or <see cref="false"/> if the timeout has been reached.</returns>
+        Task<bool> StartShutdownAsync(TimeSpan timeout);
     }
 }

--- a/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
@@ -23,16 +23,15 @@ namespace NuGet.Services.ServiceBus
         void Start();
 
         /// <summary>
-        /// Deregisters the message handler.
+        /// Deregisters the message handler and waits until currently in-flight messages have been handled.
         /// </summary>
         /// <remarks>
         /// There may still be messages in progress after the returned <see cref="Task"/> has completed!
-        /// The <see cref="NumberOfMessagesInProgress"/> property should be polled to determine when all
+        /// The <see cref="NumberOfMessagesInProgress"/> property can be polled to determine when all
         /// messages have been completed.
         /// </remarks>
-        /// <param name="timeout">The maximum amount of time this method may take to start the shutdown.</param>
-        /// <returns>A task that completes with as <see cref="true"/> when the message handler has been
-        /// deregistered, or <see cref="false"/> if the timeout has been reached.</returns>
-        Task<bool> StartShutdownAsync(TimeSpan timeout);
+        /// <param name="timeout">The maximum amount of time the shutdown may take.</param>
+        /// <returns>A task that completes as true if the shutdown succeeded gracefully.</returns>
+        Task<bool> ShutdownAsync(TimeSpan timeout);
     }
 }

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -63,7 +63,7 @@ namespace NuGet.Services.ServiceBus
 
         private async Task OnMessageAsync(IBrokeredMessage brokeredMessage)
         {
-            if (_running == false)
+            if (!running)
             {
                 _logger.LogWarning("Dropping message from Service Bus as shutdown has been initiated");
                 return;

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -63,7 +63,7 @@ namespace NuGet.Services.ServiceBus
 
         private async Task OnMessageAsync(IBrokeredMessage brokeredMessage)
         {
-            if (!running)
+            if (!_running)
             {
                 _logger.LogWarning("Dropping message from Service Bus as shutdown has been initiated");
                 return;
@@ -111,14 +111,14 @@ namespace NuGet.Services.ServiceBus
                 await Task.Delay(ShutdownPollTime);
 
                 _logger.LogInformation(
-                    "{NumberOfMessagesInProgress} certificate validations in progress after {TimeElapsed} seconds of graceful shutdown",
+                    "{NumberOfMessagesInProgress} messages in progress after {TimeElapsed} seconds of graceful shutdown",
                     _numberOfMessagesInProgress,
                     stopwatch.Elapsed.TotalSeconds);
 
                 if (stopwatch.Elapsed >= timeout)
                 {
                     _logger.LogWarning(
-                        "Forcefully shutting down even though there are {NumberOfMessagesInProgress} certificate validations in progress",
+                        "Forcefully shutting down even though there are {NumberOfMessagesInProgress} messages in progress",
                         _numberOfMessagesInProgress);
 
                     return false;

--- a/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
@@ -167,7 +167,7 @@ namespace NuGet.Services.ServiceBus.Tests
             public async Task StopReturnsTrueIfClientCloseAsyncMethodFinishesFirst()
             {
                 // Arrange
-                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromMilliseconds(5)));
+                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromMilliseconds(1)));
 
                 // Act & Assert
                 Assert.True(await _target.StartShutdownAsync(timeout: TimeSpan.FromDays(1)));
@@ -180,7 +180,7 @@ namespace NuGet.Services.ServiceBus.Tests
                 _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromDays(1)));
 
                 // Act & Assert
-                Assert.False(await _target.StartShutdownAsync(timeout: TimeSpan.FromMilliseconds(5)));
+                Assert.False(await _target.StartShutdownAsync(timeout: TimeSpan.FromMilliseconds(1)));
             }
         }
 

--- a/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
@@ -151,36 +151,16 @@ namespace NuGet.Services.ServiceBus.Tests
             }
         }
 
-        public class TheStartShutdownAsyncMethod : Base
+        public class TheShutdownAsyncMethod : Base
         {
             [Fact]
             public async Task ShutdownCallsTheClientsCloseAsyncMethod()
             {
                 // Act
-                await _target.StartShutdownAsync(TimeSpan.FromDays(1));
+                await _target.ShutdownAsync(TimeSpan.FromDays(1));
 
                 // Assert
                 _client.Verify(c => c.CloseAsync(), Times.Once);
-            }
-
-            [Fact]
-            public async Task ShutdownReturnsTrueIfClientCloseAsyncMethodFinishesFirst()
-            {
-                // Arrange
-                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromMilliseconds(1)));
-
-                // Act & Assert
-                Assert.True(await _target.StartShutdownAsync(timeout: TimeSpan.FromDays(1)));
-            }
-
-            [Fact]
-            public async Task ShutdownReturnsFalseIfClientCloseAsyncMethodTakesTooLong()
-            {
-                // Arrange
-                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromDays(1)));
-
-                // Act & Assert
-                Assert.False(await _target.StartShutdownAsync(timeout: TimeSpan.FromMilliseconds(1)));
             }
 
             [Fact]
@@ -208,7 +188,7 @@ namespace NuGet.Services.ServiceBus.Tests
 
                 await onMessageAsync(_brokeredMessage.Object);
 
-                var shutdownTask = _target.StartShutdownAsync(TimeSpan.FromDays(1));
+                var shutdownTask = _target.ShutdownAsync(TimeSpan.FromDays(1));
 
                 await onMessageAsync(brokeredMessage2.Object);
                 await shutdownTask;

--- a/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
@@ -157,10 +157,30 @@ namespace NuGet.Services.ServiceBus.Tests
             public async Task StopCallsTheClientsCloseAsyncMethod()
             {
                 // Act
-                await _target.StartShutdownAsync();
+                await _target.StartShutdownAsync(TimeSpan.FromDays(1));
 
                 // Assert
                 _client.Verify(c => c.CloseAsync(), Times.Once);
+            }
+
+            [Fact]
+            public async Task StopReturnsTrueIfClientCloseAsyncMethodFinishesFirst()
+            {
+                // Arrange
+                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromMilliseconds(5)));
+
+                // Act & Assert
+                Assert.True(await _target.StartShutdownAsync(timeout: TimeSpan.FromDays(1)));
+            }
+
+            [Fact]
+            public async Task StopReturnsFalseIfClientCloseAsyncMethodTakesTooLong()
+            {
+                // Arrange
+                _client.Setup(c => c.CloseAsync()).Returns(Task.Delay(TimeSpan.FromDays(1)));
+
+                // Act & Assert
+                Assert.False(await _target.StartShutdownAsync(timeout: TimeSpan.FromMilliseconds(5)));
             }
         }
 


### PR DESCRIPTION
Today, the Orchestrator has custom code to ensure that:

1. New Service Bus messages are dropped once shutdown has started
2. Shutting down Service Bus does not block the current thread

This brings the logic to the `SubscriptionProcessor` so that all other jobs can also have these guarantees.

Part of https://github.com/NuGet/Engineering/issues/1115