### PR TITLE
Scope around ServiceBus message processing

### DIFF
--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -73,19 +73,24 @@ namespace NuGet.Services.ServiceBus
 
             try
             {
-                _logger.LogInformation("Received message from Service Bus subscription, processing");
-
-                var message = _serializer.Deserialize(brokeredMessage);
-
-                if (await _handler.HandleAsync(message))
+                using (var scope = _logger.BeginScope($"{nameof(SubscriptionProcessor<TMessage>)}.{nameof(OnMessageAsync)} {{CallGuid}} {{CallStartTimestamp}}",
+                    Guid.NewGuid(),
+                    DateTimeOffset.UtcNow.Ticks))
                 {
-                    _logger.LogInformation("Message was successfully handled, marking the brokered message as completed");
+                    _logger.LogInformation("Received message from Service Bus subscription, processing");
 
-                    await brokeredMessage.CompleteAsync();
-                }
-                else
-                {
-                    _logger.LogInformation("Handler did not finish processing message, requeueing message to be reprocessed");
+                    var message = _serializer.Deserialize(brokeredMessage);
+
+                    if (await _handler.HandleAsync(message))
+                    {
+                        _logger.LogInformation("Message was successfully handled, marking the brokered message as completed");
+
+                        await brokeredMessage.CompleteAsync();
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Handler did not finish processing message, requeueing message to be reprocessed");
+                    }
                 }
             }
             catch (Exception e)

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -75,7 +75,7 @@ namespace NuGet.Services.ServiceBus
             {
                 using (var scope = _logger.BeginScope($"{nameof(SubscriptionProcessor<TMessage>)}.{nameof(OnMessageAsync)} {{CallGuid}} {{CallStartTimestamp}}",
                     Guid.NewGuid(),
-                    DateTimeOffset.UtcNow.Ticks))
+                    DateTimeOffset.UtcNow.ToString("O")))
                 {
                     _logger.LogInformation("Received message from Service Bus subscription, processing");
 


### PR DESCRIPTION
Added a scope around message processing in SubscriptionProcessor that should make it easier to correlate log entries across library boundaries.

A guid is generated per call, plus `DateTimeOffset.UtcNow.Ticks` is reported. The latter would allow grouping and ordering single call logs by start time. The former would allow to distinguish between calls in case they are close enough so that Ticks are the same.