### PR TITLE
[Orchestrator] Expose the Service Bus delivery count

### DIFF
--- a/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
@@ -10,7 +10,9 @@ namespace NuGet.Services.ServiceBus
     public interface IBrokeredMessage : IDisposable
     {
         int DeliveryCount { get; }
+        DateTimeOffset ExpiresAtUtc { get; }
         IDictionary<string, object> Properties { get; }
+        DateTimeOffset EnqueuedTimeUtc { get; }
         DateTimeOffset ScheduledEnqueueTimeUtc { get; set; }
         Task CompleteAsync();
         Task AbandonAsync();

--- a/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
@@ -9,6 +9,7 @@ namespace NuGet.Services.ServiceBus
 {
     public interface IBrokeredMessage : IDisposable
     {
+        int DeliveryCount { get; }
         IDictionary<string, object> Properties { get; }
         DateTimeOffset ScheduledEnqueueTimeUtc { get; set; }
         Task CompleteAsync();

--- a/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
@@ -22,6 +22,7 @@ namespace NuGet.Services.ServiceBus
 
         public BrokeredMessage BrokeredMessage { get; }
 
+        public int DeliveryCount => BrokeredMessage.DeliveryCount;
         public IDictionary<string, object> Properties => BrokeredMessage.Properties;
 
         public DateTimeOffset ScheduledEnqueueTimeUtc

--- a/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
@@ -22,8 +22,10 @@ namespace NuGet.Services.ServiceBus
 
         public BrokeredMessage BrokeredMessage { get; }
 
+        public DateTimeOffset ExpiresAtUtc => new DateTimeOffset(BrokeredMessage.ExpiresAtUtc);
         public int DeliveryCount => BrokeredMessage.DeliveryCount;
         public IDictionary<string, object> Properties => BrokeredMessage.Properties;
+        public DateTimeOffset EnqueuedTimeUtc => new DateTimeOffset(BrokeredMessage.EnqueuedTimeUtc);
 
         public DateTimeOffset ScheduledEnqueueTimeUtc
         {

--- a/src/NuGet.Services.Validation/PackageValidationMessageData.cs
+++ b/src/NuGet.Services.Validation/PackageValidationMessageData.cs
@@ -7,7 +7,19 @@ namespace NuGet.Services.Validation
 {
     public class PackageValidationMessageData
     {
-        public PackageValidationMessageData(string packageId, string packageVersion, Guid validationTrackingId)
+        public PackageValidationMessageData(
+            string packageId,
+            string packageVersion,
+            Guid validationTrackingId)
+          : this(packageId, packageVersion, validationTrackingId, deliveryCount: 0)
+        {
+        }
+
+        internal PackageValidationMessageData(
+            string packageId,
+            string packageVersion,
+            Guid validationTrackingId,
+            int deliveryCount)
         {
             if (validationTrackingId == Guid.Empty)
             {
@@ -17,10 +29,12 @@ namespace NuGet.Services.Validation
             PackageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
             PackageVersion = packageVersion ?? throw new ArgumentNullException(nameof(packageVersion));
             ValidationTrackingId = validationTrackingId;
+            DeliveryCount = deliveryCount;
         }
 
         public string PackageId { get; }
         public string PackageVersion { get; }
         public Guid ValidationTrackingId { get; }
+        public int DeliveryCount { get; }
     }
 }

--- a/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
+++ b/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
@@ -29,7 +29,8 @@ namespace NuGet.Services.Validation
             return new PackageValidationMessageData(
                 data.PackageId,
                 data.PackageVersion,
-                data.ValidationTrackingId);
+                data.ValidationTrackingId,
+                message.DeliveryCount);
         }
 
         [Schema(Name = PackageValidationSchemaName, Version = 1)]

--- a/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
@@ -18,6 +18,7 @@ namespace NuGet.Services.Validation.Tests
         private static readonly Guid ValidationTrackingId = new Guid("14b4c1b8-40e2-4d60-9db7-4b7195e807f5");
         private const string PackageValidationMessageDataType = "PackageValidationMessageData";
         private const int SchemaVersion1 = 1;
+        private const int DeliveryCount = 2;
 
         public class TheSerializePackageValidationMessageDataMethod : Base
         {
@@ -57,6 +58,7 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(PackageId, output.PackageId);
                 Assert.Equal(PackageVersion, output.PackageVersion);
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
+                Assert.Equal(DeliveryCount, output.DeliveryCount);
             }
 
             [Fact]
@@ -143,6 +145,9 @@ namespace NuGet.Services.Validation.Tests
                 brokeredMessage
                     .Setup(x => x.GetBody())
                     .Returns(TestData.SerializedPackageValidationMessageData1);
+                brokeredMessage
+                    .Setup(x => x.DeliveryCount)
+                    .Returns(DeliveryCount);
                 brokeredMessage
                     .Setup(x => x.Properties)
                     .Returns(new Dictionary<string, object>


### PR DESCRIPTION
Adds the Service Bus message's delivery count to `PackageValidationMessageData`. This will allow the Orchestrator to make decisions based off how many times a validation message has been tried.

Progress on https://github.com/NuGet/Engineering/issues/1100