### PR TITLE
Add ITelemetryClient and TelemetryClientWrapper

### DIFF
--- a/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
+++ b/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Services.Logging
+{
+    public interface ITelemetryClient
+    {
+        void TrackMetric(
+            string metricName,
+            double value,
+            IDictionary<string, string> properties = null);
+
+        void TrackException(
+            Exception exception,
+            IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null);
+    }
+}

--- a/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
+++ b/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Logging\ITelemetryClient.cs" />
     <Compile Include="ServiceBus\IBrokeredMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -46,10 +46,17 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="RequestTelemetryProcessor.cs" />
+    <Compile Include="TelemetryClientWrapper.cs" />
     <Compile Include="TelemetryContextInitializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj">
+      <Project>{6674b4b4-2d0e-4840-8cf0-2356acde8863}</Project>
+      <Name>NuGet.Services.Contracts</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\sign.targets" />

--- a/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+
+namespace NuGet.Services.Logging
+{
+    public class TelemetryClientWrapper : ITelemetryClient
+    {
+        private readonly TelemetryClient _telemetryClient;
+
+        private TelemetryClientWrapper(TelemetryClient telemetryClient)
+        {
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void TrackException(
+            Exception exception,
+            IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null)
+        {
+            try
+            {
+                _telemetryClient.TrackException(exception, properties, metrics);
+            }
+            catch
+            {
+                // logging failed, don't allow exception to escape
+            }
+        }
+
+        public void TrackMetric(
+            string metricName,
+            double value,
+            IDictionary<string, string> properties = null)
+        {
+            try
+            {
+                _telemetryClient.TrackMetric(metricName, value, properties);
+            }
+            catch
+            {
+                // logging failed, don't allow exception to escape
+            }
+        }
+    }
+}


### PR DESCRIPTION
This moves the implementation from NuGetGallery to ServerCommon.

This is helpful for unit tests `Track*` methods on `TelemetryService`.