### PR TITLE
Add TrackDuration extension

### DIFF
--- a/src/NuGet.Services.Logging/DurationMetric.cs
+++ b/src/NuGet.Services.Logging/DurationMetric.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace NuGet.Services.Logging
+{
+    /// <summary>
+    /// An object that records the duration of its existence.
+    /// </summary>
+    public class DurationMetric : IDisposable
+    {
+        private readonly ITelemetryClient _telemetry;
+
+        private readonly string _name;
+        private readonly IDictionary<string, string> _properties;
+        private readonly Stopwatch _timer;
+
+        public DurationMetric(ITelemetryClient telemetry, string name, IDictionary<string, string> properties = null)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+
+            _name = name;
+            _properties = properties;
+            _timer = Stopwatch.StartNew();
+        }
+
+        public void Dispose() => _telemetry.TrackMetric(_name, _timer.Elapsed.TotalSeconds, _properties);
+    }
+}

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -41,11 +41,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationInsights.cs" />
+    <Compile Include="DurationMetric.cs" />
     <Compile Include="ExceptionTelemetryProcessor.cs" />
     <Compile Include="LoggingSetup.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="RequestTelemetryProcessor.cs" />
+    <Compile Include="TelemetryClientExtensions.cs" />
     <Compile Include="TelemetryClientWrapper.cs" />
     <Compile Include="TelemetryContextInitializer.cs" />
   </ItemGroup>

--- a/src/NuGet.Services.Logging/TelemetryClientExtensions.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Services.Logging
+{
+    public static class TelemetryClientExtensions
+    {
+        public static IDisposable TrackDuration(
+            this ITelemetryClient telemetry,
+            string metricName,
+            IDictionary<string, string> properties = null)
+        {
+            return new DurationMetric(telemetry, metricName, properties);
+        }
+    }
+}

--- a/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
+++ b/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
@@ -42,9 +42,14 @@
     <Compile Include="LoggingSetupTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestTelemetryProcessorTests.cs" />
+    <Compile Include="TelemetryClientExtensionsTests.cs" />
     <Compile Include="TelemetryProcessorTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj">
+      <Project>{6674B4B4-2D0E-4840-8CF0-2356ACDE8863}</Project>
+      <Name>NuGet.Services.Contracts</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Services.Logging\NuGet.Services.Logging.csproj">
       <Project>{088f2bf5-1220-4125-bc64-601c2f032c13}</Project>
       <Name>NuGet.Services.Logging</Name>

--- a/tests/NuGet.Services.Logging.Tests/TelemetryClientExtensionsTests.cs
+++ b/tests/NuGet.Services.Logging.Tests/TelemetryClientExtensionsTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.Logging.Tests
+{
+    public class TelemetryClientExtensionsTests
+    {
+        public class TrackDuration : Base
+        {
+            [Fact]
+            public void ReturnsDurationMetric()
+            {
+                Assert.IsType<DurationMetric>(_target.Object.TrackDuration("test"));
+            }
+
+            [Fact]
+            public void TracksMetricOnDispose()
+            {
+                // Arrange
+                var name = "Hello.World";
+                var properties = new Dictionary<string, string>
+                {
+                    { "foo", "bar" }
+                };
+
+                // Act & Assert
+                using (_target.Object.TrackDuration(name, properties))
+                {
+                }
+
+                _target.Verify(t => t.TrackMetric(name, It.Is<double>(d => d > 0), properties));
+            }
+        }
+    }
+
+    public class Base
+    {
+        protected readonly Mock<ITelemetryClient> _target;
+
+        public Base()
+        {
+            _target = new Mock<ITelemetryClient>();
+        }
+    }
+}

--- a/tests/NuGet.Services.Logging.Tests/TelemetryClientExtensionsTests.cs
+++ b/tests/NuGet.Services.Logging.Tests/TelemetryClientExtensionsTests.cs
@@ -35,15 +35,15 @@ namespace NuGet.Services.Logging.Tests
                 _target.Verify(t => t.TrackMetric(name, It.Is<double>(d => d > 0), properties));
             }
         }
-    }
 
-    public class Base
-    {
-        protected readonly Mock<ITelemetryClient> _target;
-
-        public Base()
+        public class Base
         {
-            _target = new Mock<ITelemetryClient>();
+            protected readonly Mock<ITelemetryClient> _target;
+
+            public Base()
+            {
+                _target = new Mock<ITelemetryClient>();
+            }
         }
     }
 }


### PR DESCRIPTION
Add a `TrackDuration` method. This allows you to easily instrument duration of code like so:

```cs
using (_telemetryClient.TrackDuration("my_service.time_to_download_package"))
{
   // Do some expensive operation whose duration should be tracked
  _packageDownloadService.DownloadPackage("My.Package", "1.0.0");
}
```

