### PR TITLE
Add dequeue count to NuGet.Services.Storage queue abstraction

### DIFF
--- a/src/NuGet.Services.Storage/AzureStorageQueue.cs
+++ b/src/NuGet.Services.Storage/AzureStorageQueue.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Storage
 
         public async Task AddAsync(string contents, CancellationToken token)
         {
-            var azureMessage = new AzureStorageQueueMessage(contents);
+            var azureMessage = new AzureStorageQueueMessage(contents, dequeueCount: 0);
             await (await _queueTask.Value).AddMessageAsync(azureMessage.Message, token);
         }
 

--- a/src/NuGet.Services.Storage/AzureStorageQueueMessage.cs
+++ b/src/NuGet.Services.Storage/AzureStorageQueueMessage.cs
@@ -10,13 +10,13 @@ namespace NuGet.Services.Storage
         internal CloudQueueMessage Message { get; }
 
         internal AzureStorageQueueMessage(CloudQueueMessage message)
-            : base(message.AsString)
+            : base(message.AsString, message.DequeueCount)
         {
             Message = message;
         }
 
-        internal AzureStorageQueueMessage(string contents)
-            : base(contents)
+        internal AzureStorageQueueMessage(string contents, int dequeueCount)
+            : base(contents, dequeueCount)
         {
             Message = new CloudQueueMessage(contents);
         }

--- a/src/NuGet.Services.Storage/DeserializedStorageQueueMessage.cs
+++ b/src/NuGet.Services.Storage/DeserializedStorageQueueMessage.cs
@@ -11,7 +11,7 @@ namespace NuGet.Services.Storage
         internal StorageQueueMessage Message { get; }
 
         public DeserializedStorageQueueMessage(T contents, StorageQueueMessage message)
-            : base(contents)
+            : base(contents, message.DequeueCount)
         {
             Message = message;
         }

--- a/src/NuGet.Services.Storage/StorageQueue.cs
+++ b/src/NuGet.Services.Storage/StorageQueue.cs
@@ -50,7 +50,7 @@ namespace NuGet.Services.Storage
             }
             else
             {
-                return new StorageQueueMessage(_messageSerializer.Serialize(message.Contents));
+                return new StorageQueueMessage(_messageSerializer.Serialize(message.Contents), message.DequeueCount);
             }
         }
 

--- a/src/NuGet.Services.Storage/StorageQueueMessage.cs
+++ b/src/NuGet.Services.Storage/StorageQueueMessage.cs
@@ -6,20 +6,24 @@ namespace NuGet.Services.Storage
     public class StorageQueueMessage
     {
         public string Contents { get; }
+        public int DequeueCount { get; }
 
-        public StorageQueueMessage(string contents)
+        public StorageQueueMessage(string contents, int dequeueCount)
         {
             Contents = contents;
+            DequeueCount = dequeueCount;
         }
     }
 
     public class StorageQueueMessage<T>
     {
         public T Contents { get; }
+        public int DequeueCount { get; }
 
-        public StorageQueueMessage(T contents)
+        public StorageQueueMessage(T contents, int dequeueCount)
         {
             Contents = contents;
+            DequeueCount = dequeueCount;
         }
     }
 }


### PR DESCRIPTION
So I don't need this shenanigans:

https://github.com/NuGet/NuGet.Services.Metadata/blob/e18d2e1811e95537bc2f4da5196303601d893e10/src/V3PerPackage/PerWorkerProcessor.cs#L102-L116