### PR TITLE
Secret injection rework and enhancement

### DIFF
--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Secret\BaseToken.cs" />
     <Compile Include="Secret\IToken.cs" />
     <Compile Include="Secret\ITokenizer.cs" />
+    <Compile Include="Secret\RecursiveToken.cs" />
     <Compile Include="Secret\SecretToken.cs" />
     <Compile Include="Secret\SimpleTokenizer.cs" />
     <Compile Include="Secret\UrlEncodingToken.cs" />

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -54,10 +54,17 @@
     <Compile Include="SecretInjector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="Secret\BaseToken.cs" />
+    <Compile Include="Secret\IToken.cs" />
+    <Compile Include="Secret\ITokenizer.cs" />
+    <Compile Include="Secret\SecretToken.cs" />
+    <Compile Include="Secret\SimpleTokenizer.cs" />
+    <Compile Include="Secret\VerbatimStringToken.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\sign.targets" />
 </Project>

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Secret\ITokenizer.cs" />
     <Compile Include="Secret\SecretToken.cs" />
     <Compile Include="Secret\SimpleTokenizer.cs" />
+    <Compile Include="Secret\UrlEncodingToken.cs" />
     <Compile Include="Secret\VerbatimStringToken.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.KeyVault/Secret/BaseToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/BaseToken.cs
@@ -6,34 +6,19 @@ using System;
 namespace NuGet.Services.KeyVault.Secret
 {
     /// <summary>
-    /// Base token implementation that contains token "value" and has default equality
-    /// implementation that returns true iff other type is the same as the derived and 
-    /// "values" are the same. It mostly exists to make testing easier
+    /// Base token implementation that contains token "value".
+    /// It mostly exists to make testing easier
     /// </summary>
-    /// <typeparam name="T">The concrete derived type</typeparam>
-    /// <remarks>The first level of descendants of this class must be sealed</remarks>
-    public abstract class BaseToken<T>
-        where T: BaseToken<T>
+    public abstract class BaseToken
     {
-        protected string Value { get; }
+        public string Value { get; }
 
         public BaseToken(string value)
         {
             Value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        public bool Equals(IToken other)
-        {
-            var concreteOther = other as T;
-            if (concreteOther == null)
-            {
-                return false;
-            }
-
-            return concreteOther.Value == Value;
-        }
-
         public override string ToString()
-            => $"{typeof(T).Name}({Value})";
+            => $"{GetType().Name}({Value})";
     }
 }

--- a/src/NuGet.Services.KeyVault/Secret/BaseToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/BaseToken.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    /// <summary>
+    /// Base token implementation that contains token "value" and has default equality
+    /// implementation that returns true iff other type is the same as the derived and 
+    /// "values" are the same. It mostly exists to make testing easier
+    /// </summary>
+    /// <typeparam name="T">The concrete derived type</typeparam>
+    /// <remarks>The first level of descendants of this class must be sealed</remarks>
+    public abstract class BaseToken<T>
+        where T: BaseToken<T>
+    {
+        protected string Value { get; }
+
+        public BaseToken(string value)
+        {
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public bool Equals(IToken other)
+        {
+            var concreteOther = other as T;
+            if (concreteOther == null)
+            {
+                return false;
+            }
+
+            return concreteOther.Value == Value;
+        }
+
+        public override string ToString()
+            => $"{typeof(T).Name}({Value})";
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/IToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/IToken.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    /// <summary>
+    /// Represents a token in the text with secrets
+    /// </summary>
+    public interface IToken : IEquatable<IToken>
+    {
+        /// <summary>
+        /// Processes the string into its final form
+        /// </summary>
+        /// <returns></returns>
+        Task<string> ProcessAsync();
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/IToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/IToken.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault.Secret
@@ -9,7 +8,7 @@ namespace NuGet.Services.KeyVault.Secret
     /// <summary>
     /// Represents a token in the text with secrets
     /// </summary>
-    public interface IToken : IEquatable<IToken>
+    public interface IToken
     {
         /// <summary>
         /// Processes the string into its final form

--- a/src/NuGet.Services.KeyVault/Secret/ITokenizer.cs
+++ b/src/NuGet.Services.KeyVault/Secret/ITokenizer.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    public interface ITokenizer
+    {
+        /// <summary>
+        /// Splits a string potentially containing secrets into a sequence of tokens
+        /// </summary>
+        IEnumerable<IToken> Tokenize(string input);
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/RecursiveToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/RecursiveToken.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    public class RecursiveToken : SecretToken, IToken
+    {
+        private readonly ISecretInjector _secretInjector;
+
+        public RecursiveToken(string secretName, ISecretReader secretReader, ISecretInjector secretInjector)
+            : base(secretName, secretReader)
+        {
+            _secretInjector = secretInjector ?? throw new ArgumentNullException(nameof(secretInjector));
+        }
+
+        public override async Task<string> ProcessAsync()
+        {
+            var value = await base.ProcessAsync();
+            return await _secretInjector.InjectAsync(value);
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/RecursiveToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/RecursiveToken.cs
@@ -6,6 +6,10 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault.Secret
 {
+    /// <summary>
+    /// <see cref="SecretToken"/> that treats its value as a string containing other secrets and does
+    /// additional (single) level of expansion.
+    /// </summary>
     public class RecursiveToken : SecretToken, IToken
     {
         private readonly ISecretInjector _secretInjector;

--- a/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.KeyVault.Secret
             _secretReader = secretReader ?? throw new ArgumentNullException(nameof(secretReader));
         }
 
-        public async Task<string> ProcessAsync()
+        public virtual async Task<string> ProcessAsync()
             => await _secretReader.GetSecretAsync(SecretName);
     }
 }

--- a/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    /// <summary>
+    /// <see cref="IToken"/> that gets simple secret name -> secret value substitution
+    /// </summary>
+    public sealed class SecretToken : BaseToken<SecretToken>, IToken
+    {
+        private readonly ISecretReader _secretReader;
+
+        private string SecretName => Value;
+
+        public SecretToken(string secretName, ISecretReader secretReader)
+            : base(secretName)
+        {
+            _secretReader = secretReader ?? throw new ArgumentNullException(nameof(secretReader));
+        }
+
+        public async Task<string> ProcessAsync()
+            => await _secretReader.GetSecretAsync(SecretName);
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/SecretToken.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 namespace NuGet.Services.KeyVault.Secret
 {
     /// <summary>
-    /// <see cref="IToken"/> that gets simple secret name -> secret value substitution
+    /// <see cref="IToken"/> that does simple secret name -> secret value substitution
     /// </summary>
-    public sealed class SecretToken : BaseToken<SecretToken>, IToken
+    public class SecretToken : BaseToken, IToken
     {
         private readonly ISecretReader _secretReader;
 

--- a/src/NuGet.Services.KeyVault/Secret/SimpleTokenizer.cs
+++ b/src/NuGet.Services.KeyVault/Secret/SimpleTokenizer.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    public class SimpleTokenizer : ITokenizer
+    {
+        private const string DefaultFrame = "$$";
+
+        private readonly string _frame;
+        private readonly ISecretReader _secretReader;
+
+        public SimpleTokenizer(string frame, ISecretReader secretReader)
+        {
+            _frame = frame ?? throw new ArgumentNullException(nameof(frame));
+            _secretReader = secretReader ?? throw new ArgumentNullException(nameof(secretReader));
+        }
+
+        public IEnumerable<IToken> Tokenize(string input)
+        {
+            int verbatimStartIndex = 0;
+            int foundIndex;
+            bool insideFrame = false;
+            int frameStartIndex = 0;
+
+            while ((foundIndex = input.IndexOf(_frame, frameStartIndex, StringComparison.InvariantCulture)) >= 0)
+            { 
+                if (insideFrame)
+                {
+                    var secretTokenValue = input.Substring(frameStartIndex, foundIndex - frameStartIndex);
+                    if (!string.IsNullOrWhiteSpace(secretTokenValue))
+                    {
+                        var precedingVerbatimText = input.Substring(verbatimStartIndex, frameStartIndex - verbatimStartIndex - _frame.Length);
+                        // keep whitespace in verbatim text
+                        if (!string.IsNullOrEmpty(precedingVerbatimText))
+                        {
+                            yield return new VerbatimStringToken(precedingVerbatimText);
+                        }
+                        yield return new SecretToken(secretTokenValue, _secretReader);
+
+                        insideFrame = false;
+                        verbatimStartIndex = foundIndex + _frame.Length;
+                        frameStartIndex = verbatimStartIndex;
+                    }
+                    else
+                    {
+                        // if what we found does not look like a secret name, advance the frame
+                        // start index to current position
+                        frameStartIndex = foundIndex + _frame.Length;
+                    }
+                }
+                else
+                {
+                    frameStartIndex = foundIndex + _frame.Length;
+                    insideFrame = true;
+                }
+            }
+            var trailingVerbatimText = input.Substring(verbatimStartIndex);
+            if (!string.IsNullOrEmpty(trailingVerbatimText))
+            {
+                yield return new VerbatimStringToken(trailingVerbatimText);
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/UrlEncodingToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/UrlEncodingToken.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    public class UrlEncodingToken : SecretToken, IToken
+    {
+        public UrlEncodingToken(string secretName, ISecretReader secretReader)
+            : base(secretName, secretReader)
+        {
+        }
+
+        public override async Task<string> ProcessAsync()
+        {
+            string value = await base.ProcessAsync();
+            return Uri.EscapeDataString(value);
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/Secret/UrlEncodingToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/UrlEncodingToken.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault.Secret
 {
+    /// <summary>
+    /// <see cref="SecretToken"/> that urlencodes its value.
+    /// </summary>
     public class UrlEncodingToken : SecretToken, IToken
     {
         public UrlEncodingToken(string secretName, ISecretReader secretReader)

--- a/src/NuGet.Services.KeyVault/Secret/VerbatimStringToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/VerbatimStringToken.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault.Secret
@@ -9,7 +8,7 @@ namespace NuGet.Services.KeyVault.Secret
     /// <summary>
     /// <see cref="IToken"/> that does no processing and just returns its value
     /// </summary>
-    public sealed class VerbatimStringToken : BaseToken<VerbatimStringToken>, IToken
+    public class VerbatimStringToken : BaseToken, IToken
     {
         public VerbatimStringToken(string value)
             : base(value)

--- a/src/NuGet.Services.KeyVault/Secret/VerbatimStringToken.cs
+++ b/src/NuGet.Services.KeyVault/Secret/VerbatimStringToken.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault.Secret
+{
+    /// <summary>
+    /// <see cref="IToken"/> that does no processing and just returns its value
+    /// </summary>
+    public sealed class VerbatimStringToken : BaseToken<VerbatimStringToken>, IToken
+    {
+        public VerbatimStringToken(string value)
+            : base(value)
+        {
+        }
+
+        public Task<string> ProcessAsync()
+            => Task.FromResult(Value);
+    }
+}

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -2,36 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Services.KeyVault.Secret;
 
 namespace NuGet.Services.KeyVault
 {
     public class SecretInjector : ISecretInjector
     {
         public const string DefaultFrame = "$$";
-        private readonly string _frame;
-        private readonly ISecretReader _secretReader;
+        private readonly ITokenizer _tokenizer;
 
-        public SecretInjector(ISecretReader secretReader) :this(secretReader, DefaultFrame)
+        public SecretInjector(ISecretReader secretReader) 
+            : this(new SimpleTokenizer(DefaultFrame, secretReader))
         {
         }
 
-        public SecretInjector(ISecretReader secretReader, string frame)
+        public SecretInjector(ITokenizer tokenizer)
         {
-            if (secretReader == null)
-            {
-                throw new ArgumentNullException(nameof(secretReader));
-            }
-
-            if (string.IsNullOrWhiteSpace(frame))
-            {
-                throw new ArgumentException("Frame argument is null or empty.");
-            }
-
-            _frame = frame;
-            _secretReader = secretReader;
+            _tokenizer = tokenizer ?? throw new ArgumentNullException(nameof(tokenizer));
         }
 
         public async Task<string> InjectAsync(string input)
@@ -41,50 +30,14 @@ namespace NuGet.Services.KeyVault
                 return input;
             }
 
-            var output = new StringBuilder(input);
-            var secretNames = GetSecretNames(input);
+            var output = new StringBuilder();
 
-            foreach (var secretName in secretNames)
+            foreach (var token in _tokenizer.Tokenize(input))
             {
-                var secretValue = await _secretReader.GetSecretAsync(secretName);
-                output.Replace($"{_frame}{secretName}{_frame}", secretValue);
+                output.Append(await token.ProcessAsync());
             }
 
             return output.ToString();
-        }
-
-        private IEnumerable<string> GetSecretNames(string input)
-        {
-            var secretNames = new HashSet<string>();
-
-            int startIndex = 0;
-            int foundIndex;
-            bool insideFrame = false;
-
-            do
-            {
-                foundIndex = input.IndexOf(_frame, startIndex, StringComparison.InvariantCulture);
-
-                if (insideFrame && foundIndex > 0)
-                {
-                    var secret = input.Substring(startIndex, foundIndex - startIndex);
-                    if (!string.IsNullOrWhiteSpace(secret))
-                    {
-                        secretNames.Add(secret);
-                    }
-
-                    insideFrame = false;
-                }
-                else
-                {
-                    insideFrame = true;
-                }
-
-                startIndex = foundIndex + _frame.Length;
-
-            } while (foundIndex >= 0);
-
-            return secretNames;
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -10,11 +10,10 @@ namespace NuGet.Services.KeyVault
 {
     public class SecretInjector : ISecretInjector
     {
-        public const string DefaultFrame = "$$";
         private readonly ITokenizer _tokenizer;
 
         public SecretInjector(ISecretReader secretReader) 
-            : this(new SimpleTokenizer(DefaultFrame, secretReader))
+            : this(new SimpleTokenizer(secretReader))
         {
         }
 

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -13,8 +13,8 @@ namespace NuGet.Services.KeyVault
         private readonly ITokenizer _tokenizer;
 
         public SecretInjector(ISecretReader secretReader) 
-            : this(new SimpleTokenizer(secretReader))
         {
+            _tokenizer = new SimpleTokenizer(secretReader, this);
         }
 
         public SecretInjector(ITokenizer tokenizer)

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.KeyVault.Tests
         }
 
         [Theory]
-        [MemberData("_testFormatParameters")]
+        [MemberData(nameof(_testFormatParameters))]
         public async Task TestFormat(string input, string expectedOutput)
         {
             // Act

--- a/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
+++ b/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="CachingSecretReaderFacts.cs" />
     <Compile Include="KeyVaultReaderFormatterFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RecursiveTokenFacts.cs" />
     <Compile Include="SecretTokenFacts.cs" />
     <Compile Include="SimpleTokenizerFacts.cs" />
     <Compile Include="UrlEncodingTokenFacts.cs" />

--- a/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
+++ b/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="CachingSecretReaderFacts.cs" />
     <Compile Include="KeyVaultReaderFormatterFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleTokenizerFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
+++ b/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
@@ -42,7 +42,10 @@
     <Compile Include="CachingSecretReaderFacts.cs" />
     <Compile Include="KeyVaultReaderFormatterFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SecretTokenFacts.cs" />
     <Compile Include="SimpleTokenizerFacts.cs" />
+    <Compile Include="UrlEncodingTokenFacts.cs" />
+    <Compile Include="VerbatimStringTokenFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/tests/NuGet.Services.KeyVault.Tests/RecursiveTokenFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/RecursiveTokenFacts.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.KeyVault.Secret;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class RecursiveTokenFacts
+    {
+        [Fact]
+        public void ThrowsWhenSecretNameIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RecursiveToken(null, _secretReaderMock.Object, _secretInjectorMock.Object));
+        }
+
+        [Fact]
+        public void ThrowsWhenSecretReaderIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new RecursiveToken("somename", null, _secretInjectorMock.Object));
+            Assert.Equal("secretReader", ex.ParamName);
+        }
+
+        [Fact]
+        public void ThrowsWhenSecretInjectorIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new RecursiveToken("somename", _secretReaderMock.Object, null));
+            Assert.Equal("secretInjector", ex.ParamName);
+        }
+
+        [Fact]
+        public async Task DoesRecursiveExpansion()
+        {
+            const string secretName = "someName";
+            const string innerSecretName = "anotherSecretName";
+            const string secretValue = "$$" + innerSecretName + "$$";
+            const string innerSecretInjectionResult = "42";
+            _secretReaderMock
+                .Setup(sr => sr.GetSecretAsync(secretName))
+                .ReturnsAsync(secretValue);
+            _secretInjectorMock
+                .Setup(si => si.InjectAsync(secretValue))
+                .ReturnsAsync(innerSecretInjectionResult);
+
+            var target = Create(secretName);
+
+            var result = await target.ProcessAsync();
+
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(secretName), Times.Once);
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(It.IsAny<string>()), Times.Once);
+
+            _secretInjectorMock
+                .Verify(si => si.InjectAsync(secretValue), Times.Once);
+            _secretInjectorMock
+                .Verify(si => si.InjectAsync(It.IsAny<string>()), Times.Once);
+
+            Assert.Same(innerSecretInjectionResult, result);
+        }
+
+        [Fact]
+        public async Task DoesOnlyOneLevelOfExpansion()
+        {
+            const string topLevelSecretName = "topLevelName";
+            const string secondLevelSecretName = "secondLevelName";
+            const string thirdLevelSecretName = "thirdLevelName";
+            const string topLevelSecretValue = "$$" + secondLevelSecretName + "$$";
+            const string secondLevelSecretValue = "$$" + thirdLevelSecretName + "$$";
+
+            _secretReaderMock
+                .Setup(sr => sr.GetSecretAsync(topLevelSecretName))
+                .ReturnsAsync(topLevelSecretValue);
+            _secretInjectorMock
+                .Setup(si => si.InjectAsync(topLevelSecretValue))
+                .ReturnsAsync(secondLevelSecretValue);
+
+            var target = Create(topLevelSecretName);
+            var result = await target.ProcessAsync();
+
+            Assert.Same(secondLevelSecretValue, result);
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(secondLevelSecretName), Times.Never);
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(thirdLevelSecretName), Times.Never);
+            _secretInjectorMock
+                .Verify(si => si.InjectAsync(secondLevelSecretValue), Times.Never);
+        }
+
+        private Mock<ISecretReader> _secretReaderMock;
+        private Mock<ISecretInjector> _secretInjectorMock;
+
+        public RecursiveTokenFacts()
+        {
+            _secretReaderMock = new Mock<ISecretReader>();
+            _secretInjectorMock = new Mock<ISecretInjector>();
+        }
+
+        private RecursiveToken Create(string secretName)
+            => new RecursiveToken(secretName, _secretReaderMock.Object, _secretInjectorMock.Object);
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/SecretTokenFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SecretTokenFacts.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.KeyVault.Secret;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class SecretTokenFacts
+    {
+        [Fact]
+        public void ThrowsWhenNameIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new SecretToken(null, _secretReaderMock.Object));
+        }
+
+        [Fact]
+        public void ThrowsWhenSecretReaderIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new SecretToken("something", null));
+            Assert.Equal("secretReader", ex.ParamName);
+        }
+
+        [Fact]
+        public async Task ForwardsNameToSecretReader()
+        {
+            const string secretName = "secretName";
+            var target = CreateToken(secretName);
+
+            await target.ProcessAsync();
+
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(secretName), Times.Once);
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ReturnsValueFromSecretReader()
+        {
+            const string secretName = "secretName";
+            const string secretValue = "secretValue";
+            var target = CreateToken(secretName);
+            _secretReaderMock
+                .Setup(sr => sr.GetSecretAsync(secretName))
+                .ReturnsAsync(secretValue);
+
+            var response = await target.ProcessAsync();
+
+            Assert.Same(secretValue, response);
+        }
+
+        private Mock<ISecretReader> _secretReaderMock;
+
+        public SecretTokenFacts()
+        {
+            _secretReaderMock = new Mock<ISecretReader>();
+        }
+
+        private SecretToken CreateToken(string name)
+            => new SecretToken(name, _secretReaderMock.Object);
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
@@ -73,8 +73,10 @@ namespace NuGet.Services.KeyVault.Tests
         [MemberData(nameof(InputToTokenMap))]
         public void ProducesCorrectTokenSequences(string inputString, IEnumerable<BaseToken> expectedTokens)
         {
-            var response = _subject.Tokenize(inputString).OfType<BaseToken>().ToList();
-            Assert.Equal(expectedTokens, response, new BaseTokenEqualityComparer());
+            var response = _subject.Tokenize(inputString).ToList();
+            var tokens = response.OfType<BaseToken>().ToList();
+            Assert.Equal(response.Count, tokens.Count);
+            Assert.Equal(expectedTokens, tokens, new BaseTokenEqualityComparer());
         }
 
         private static Mock<ISecretReader> _secretReader = new Mock<ISecretReader>();

--- a/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
@@ -67,6 +67,12 @@ namespace NuGet.Services.KeyVault.Tests
                     Verbatim(";Password="),
                     Secret("secret2"),
                     Verbatim(";Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"))},
+            new object[]{ "$$urlencode|secretName$$", Tokens(UrlEnc("secretName")) },
+            new object[]{ "SomeText=$$urlencode|secretName$$", Tokens(Verbatim("SomeText="), UrlEnc("secretName")) },
+            new object[]{ "$$urlencode|secretName$$postfix", Tokens(UrlEnc("secretName"), Verbatim("postfix")) },
+            new object[]{ "$$regularSecret$$$$urlencode|secretName$$", Tokens(Secret("regularSecret"), UrlEnc("secretName")) },
+            new object[]{ "$$urlencode|secretName$$$$regularLaterSecret$$", Tokens(UrlEnc("secretName"), Secret("regularLaterSecret")) },
+            new object[]{ "$$urlencode|secretName$$textbetween$$otherSecret$$", Tokens(UrlEnc("secretName"), Verbatim("textbetween"), Secret("otherSecret")) },
         };
 
         [Theory]
@@ -84,7 +90,7 @@ namespace NuGet.Services.KeyVault.Tests
 
         public SimpleTokenizerFacts()
         {
-            _subject = new SimpleTokenizer("$$", _secretReader.Object);
+            _subject = new SimpleTokenizer(_secretReader.Object);
         }
 
         private static BaseToken[] Tokens(params BaseToken[] tokens)
@@ -95,6 +101,9 @@ namespace NuGet.Services.KeyVault.Tests
 
         private static SecretToken Secret(string value)
             => new SecretToken(value, _secretReader.Object);
+
+        private static UrlEncodingToken UrlEnc(string value)
+            => new UrlEncodingToken(value, _secretReader.Object);
 
         private class BaseTokenEqualityComparer : IEqualityComparer<BaseToken>
         {

--- a/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NuGet.Services.KeyVault.Secret;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class SimpleTokenizerFacts
+    {
+        public static IEnumerable<object[]> InputToTokenMap => new []
+        {
+            new object[]{ "", Tokens() },
+            new object[]{ "a", Tokens(Verbatim("a")) },
+            new object[]{ "aa", Tokens(Verbatim("aa")) },
+            new object[]{ "aaa", Tokens(Verbatim("aaa")) },
+            new object[]{ "a b", Tokens(Verbatim("a b")) },
+            new object[]{ "a bb", Tokens(Verbatim("a bb")) },
+            new object[]{ "a bbb", Tokens(Verbatim("a bbb")) },
+            new object[]{ "aa b", Tokens(Verbatim("aa b")) },
+            new object[]{ "aa bb", Tokens(Verbatim("aa bb")) },
+            new object[]{ "aa bbb", Tokens(Verbatim("aa bbb")) },
+            new object[]{ "aaa b", Tokens(Verbatim("aaa b")) },
+            new object[]{ "aaa bb", Tokens(Verbatim("aaa bb")) },
+            new object[]{ "aaa bbb", Tokens(Verbatim("aaa bbb")) },
+            new object[]{ "$$a$$", Tokens(Secret("a")) },
+            new object[]{ "$$$a$$", Tokens(Secret("$a")) },                 // yes, $a is the secret name
+            new object[]{ "$$$a$$$", Tokens(Secret("$a"), Verbatim("$")) }, // same as above
+            new object[]{ "$$aa$$", Tokens(Secret("aa")) },
+            new object[]{ "$$aaa$$", Tokens(Secret("aaa")) },
+            new object[]{ "$$ $$a$$", Tokens(Verbatim("$$ "), Secret("a")) },
+            new object[]{ "a$$b$$", Tokens(Verbatim("a"), Secret("b")) },
+            new object[]{ "a$$bb$$", Tokens(Verbatim("a"), Secret("bb")) },
+            new object[]{ "a$$bbb$$", Tokens(Verbatim("a"), Secret("bbb")) },
+            new object[]{ "aa$$b$$", Tokens(Verbatim("aa"), Secret("b")) },
+            new object[]{ "aa$$bb$$", Tokens(Verbatim("aa"), Secret("bb")) },
+            new object[]{ "aa$$bbb$$", Tokens(Verbatim("aa"), Secret("bbb")) },
+            new object[]{ "aaa$$b$$", Tokens(Verbatim("aaa"), Secret("b")) },
+            new object[]{ "aaa$$bb$$", Tokens(Verbatim("aaa"), Secret("bb")) },
+            new object[]{ "aaa$$bbb$$", Tokens(Verbatim("aaa"), Secret("bbb")) },
+            new object[]{ "$$a$$$$$b$$", Tokens(Secret("a"), Secret("$b")) },
+            new object[]{ "$$a$$$$b$$", Tokens(Secret("a"), Secret("b")) },
+            new object[]{ "$$a$$$$bb$$", Tokens(Secret("a"), Secret("bb")) },
+            new object[]{ "$$a$$$$bbb$$", Tokens(Secret("a"), Secret("bbb")) },
+            new object[]{ "$$aa$$$$b$$", Tokens(Secret("aa"), Secret("b")) },
+            new object[]{ "$$aa$$$$bb$$", Tokens(Secret("aa"), Secret("bb")) },
+            new object[]{ "$$aa$$$$bbb$$", Tokens(Secret("aa"), Secret("bbb")) },
+            new object[]{ "$$aaa$$$$b$$", Tokens(Secret("aaa"), Secret("b")) },
+            new object[]{ "$$aaa$$$$bb$$", Tokens(Secret("aaa"), Secret("bb")) },
+            new object[]{ "$$aaa$$$$bbb$$", Tokens(Secret("aaa"), Secret("bbb")) },
+            new object[]{ "aaa$$bbb", Tokens(Verbatim("aaa$$bbb")) },
+            new object[]{ "aaa$$bbb$$ccc", Tokens(Verbatim("aaa"), Secret("bbb"), Verbatim("ccc")) },
+            new object[]{ "aaa$$bbb$$ccc$$ddd$$", Tokens(Verbatim("aaa"), Secret("bbb"), Verbatim("ccc"), Secret("ddd")) },
+            new object[]{ "$", Tokens(Verbatim("$")) },
+            new object[]{ "$$", Tokens(Verbatim("$$")) },
+            new object[]{ "$$$", Tokens(Verbatim("$$$")) },
+            new object[]{ "$$$$", Tokens(Verbatim("$$$$")) },
+            new object[]{ "$$$$$", Tokens(Verbatim("$$$$$")) },
+            new object[]{ "$$$$$$", Tokens(Verbatim("$$$$$$")) },
+            new object[]{ "Server=tcp:myserver.database.windows.net,1433;Database=myDB;User ID=$$secret1$$;Password=$$secret2$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+                Tokens(
+                    Verbatim("Server=tcp:myserver.database.windows.net,1433;Database=myDB;User ID="),
+                    Secret("secret1"),
+                    Verbatim(";Password="),
+                    Secret("secret2"),
+                    Verbatim(";Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"))},
+        };
+
+        [Theory]
+        [MemberData(nameof(InputToTokenMap))]
+        public void ProducesCorrectTokenSequences(string inputString, IEnumerable<IToken> expectedTokens)
+        {
+            var response = _subject.Tokenize(inputString).ToList();
+            Assert.Equal(expectedTokens, response, EqualityComparer<IToken>.Default);
+        }
+
+        private static Mock<ISecretReader> _secretReader = new Mock<ISecretReader>();
+        private SimpleTokenizer _subject;
+
+        public SimpleTokenizerFacts()
+        {
+            _subject = new SimpleTokenizer("$$", _secretReader.Object);
+        }
+
+        private static IToken[] Tokens(params IToken[] tokens)
+            => tokens;
+
+        private static VerbatimStringToken Verbatim(string value)
+            => new VerbatimStringToken(value);
+
+        private static SecretToken Secret(string value)
+            => new SecretToken(value, _secretReader.Object);
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SimpleTokenizerFacts.cs
@@ -71,10 +71,10 @@ namespace NuGet.Services.KeyVault.Tests
 
         [Theory]
         [MemberData(nameof(InputToTokenMap))]
-        public void ProducesCorrectTokenSequences(string inputString, IEnumerable<IToken> expectedTokens)
+        public void ProducesCorrectTokenSequences(string inputString, IEnumerable<BaseToken> expectedTokens)
         {
-            var response = _subject.Tokenize(inputString).ToList();
-            Assert.Equal(expectedTokens, response, EqualityComparer<IToken>.Default);
+            var response = _subject.Tokenize(inputString).OfType<BaseToken>().ToList();
+            Assert.Equal(expectedTokens, response, new BaseTokenEqualityComparer());
         }
 
         private static Mock<ISecretReader> _secretReader = new Mock<ISecretReader>();
@@ -85,7 +85,7 @@ namespace NuGet.Services.KeyVault.Tests
             _subject = new SimpleTokenizer("$$", _secretReader.Object);
         }
 
-        private static IToken[] Tokens(params IToken[] tokens)
+        private static BaseToken[] Tokens(params BaseToken[] tokens)
             => tokens;
 
         private static VerbatimStringToken Verbatim(string value)
@@ -93,5 +93,16 @@ namespace NuGet.Services.KeyVault.Tests
 
         private static SecretToken Secret(string value)
             => new SecretToken(value, _secretReader.Object);
+
+        private class BaseTokenEqualityComparer : IEqualityComparer<BaseToken>
+        {
+            public bool Equals(BaseToken x, BaseToken y)
+                => x.GetType() == y.GetType() && x.Value == y.Value;
+
+            public int GetHashCode(BaseToken obj)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
     }
 }

--- a/tests/NuGet.Services.KeyVault.Tests/UrlEncodingTokenFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/UrlEncodingTokenFacts.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using NuGet.Services.KeyVault.Secret;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class UrlEncodingTokenFacts
+    {
+        [Fact]
+        public void ThrowsWhenNameIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new SecretToken(null, _secretReaderMock.Object));
+        }
+
+        [Fact]
+        public void ThrowsWhenSecretReaderIsNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new SecretToken("something", null));
+            Assert.Equal("secretReader", ex.ParamName);
+        }
+
+        [Fact]
+        public async Task ForwardsNameToSecretReader()
+        {
+            const string secretName = "secretName";
+            var target = CreateToken(secretName);
+
+            await target.ProcessAsync();
+
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(secretName), Times.Once);
+            _secretReaderMock
+                .Verify(sr => sr.GetSecretAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("some@email.com", "some%40email.com")]
+        [InlineData("fh@34F!j#&^", "fh%4034F%21j%23%26%5E")]
+        public async Task UrlEncodesValue(string secretValue, string expectedOutput)
+        {
+            const string secretName = "secretName";
+            var target = CreateToken(secretName);
+            _secretReaderMock
+                .Setup(sr => sr.GetSecretAsync(secretName))
+                .ReturnsAsync(secretValue);
+
+            var response = await target.ProcessAsync();
+
+            Assert.Equal(expectedOutput, response);
+        }
+
+        private Mock<ISecretReader> _secretReaderMock;
+
+        public UrlEncodingTokenFacts()
+        {
+            _secretReaderMock = new Mock<ISecretReader>();
+            _secretReaderMock
+                .Setup(sr => sr.GetSecretAsync(It.IsAny<string>()))
+                .ReturnsAsync("somevalue");
+        }
+
+        private UrlEncodingToken CreateToken(string name)
+            => new UrlEncodingToken(name, _secretReaderMock.Object);
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/VerbatimStringTokenFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/VerbatimStringTokenFacts.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGet.Services.KeyVault.Secret;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class VerbatimStringTokenFacts
+    {
+        [Fact]
+        public void ThrowsWhenValueIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new VerbatimStringToken(null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("123")]
+        [InlineData("abc")]
+        [InlineData("containing space")]
+        [InlineData("key=value;anotherkey=anothervalue")]
+        public async Task EchoesWhateverWasPassedIn(string value)
+        {
+            var token = new VerbatimStringToken(value);
+
+            var result = await token.ProcessAsync();
+            Assert.Equal(value, result);
+        }
+    }
+}


### PR DESCRIPTION
Secret injection is not simple search and replace anymore.
Email service needs credentials to be URL-encoded and it is easy to forget to urlencode the secret when updating. It is better to have have secret injector to do the conversion automatically where needed. Also, email setup needs 2 accounts for secret rotation without downtime which introduces the need to do configuration changes each time we rotate the secrets, which is again error prone and could be resolved by introducing "proxy" secret, that itself will expand to one value or another depending on its value recursively.

`ITokenizer` interface was introduced to replace simple search and replace secret injections with a bit more complicated but more flexible approach:  given a string that may contain secrets, it splits it into series of tokens, which are then reassembled into a string with injected secrets.

`IToken` represents a token produced by `ITokenizer`. It has the only `ProcessAsync` method that does whatever is necessary to produce the value of the token and returns it.

`VerbatimStringToken` is a token that contains non-secret text and just returns it when processed.

`SecretToken` is a token that stores the secret name and retrieves the value of the secret when processed.

`UrlEncodingToken` is a `SecretToken` that retrieves the secret value by name but additionally urlencodes it.

`RecursiveToken` is a `SecretToken` that retrieves the secret value by name, treats the value as a string containing secret and does another round of secret injection on it.

`SimpleTokenizer` is a tokenizer implementation based on the earlier `SecretInjector` implementation with some changes. A syntax extension for secrets was introduced: `$$secretName$$` expands into secret value as before, in addition to that `$$tokenType|secretName$$` now allows to request a specific secret value processing as in: `$$urlencode|emailpassword$$` - will retrieve `emailpassword` secret value and urlencode it and `$$recurse|somesecret$$` will retrieve `somesecret` value and inject secrets into it recursively.

### Example of email secret setup

#### KeyVault secrets
```
emailusername1=username1@example.com
emailpassword1=somepassword1
emailusername2=username2@example.com
emailpassword2=somepassword2
emailusername=$$emailusername1$$
emailpassword=$$urlencode|emailpassword1$$
```

#### Service email URL
```
smtps://$$recurse|emailusername$$:$$recurse|emailpassword$$@smtphost:3847/
```

#### Secret rotation procedure
1. Reset password for `username2` account (the one that is not in use currently);
2. Update KeyVault secret `emailpassword2` with new password;
2. Update the `emailusername` and `emailpassword` secrets in keyvault to reference `emailusername2` and `emailpassword2` secrets respectively;
3. Wait for services to pick up updates due to secret refresh or restart/redeploy affected services (no configuration update necessary);
4. Validate that `username1` credentials are not used;
5. Reset `username1` password;
6. Update `emailpassword1` value in KeyVault.