### PR TITLE
Certificates:  add new validation issue

### DIFF
--- a/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
+++ b/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
@@ -58,6 +58,11 @@ namespace NuGet.Services.Validation
         PackageIsNotSigned = 8,
 
         /// <summary>
+        /// A package is signed with an unauthorized certificate.
+        /// </summary>
+        PackageIsSignedWithUnauthorizedCertificate = 9,
+
+        /// <summary>
         /// Obsolete testing issue - do NOT use this!
         /// </summary>
         [Obsolete("This issue code should only be used for testing")]

--- a/src/NuGet.Services.Validation.Issues/NuGet.Services.Validation.Issues.csproj
+++ b/src/NuGet.Services.Validation.Issues/NuGet.Services.Validation.Issues.csproj
@@ -43,6 +43,7 @@
     <Compile Include="NoDataValidationIssue.cs" />
     <Compile Include="ObsoleteTestingIssue.cs" />
     <Compile Include="ClientSigningVerificationFailure.cs" />
+    <Compile Include="UnauthorizedCertificateFailure.cs" />
     <Compile Include="ValidationIssue.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />

--- a/src/NuGet.Services.Validation.Issues/UnauthorizedCertificateFailure.cs
+++ b/src/NuGet.Services.Validation.Issues/UnauthorizedCertificateFailure.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.Validation.Issues
+{
+    public sealed class UnauthorizedCertificateFailure : ValidationIssue
+    {
+        [JsonConstructor]
+        public UnauthorizedCertificateFailure(string sha1Thumbprint)
+        {
+            Sha1Thumbprint = sha1Thumbprint ?? throw new ArgumentNullException(nameof(sha1Thumbprint));
+        }
+
+        public override ValidationIssueCode IssueCode => ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate;
+
+        [JsonProperty("t", Required = Required.Always)]
+        public string Sha1Thumbprint { get; }
+    }
+}

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -17,6 +17,7 @@ namespace NuGet.Services.Validation.Issues
         public static ValidationIssue OnlySignatureFormatVersion1Supported { get; } = new NoDataValidationIssue(ValidationIssueCode.OnlySignatureFormatVersion1Supported);
         public static ValidationIssue AuthorCounterSignaturesNotSupported { get; } = new NoDataValidationIssue(ValidationIssueCode.AuthorCounterSignaturesNotSupported);
         public static ValidationIssue PackageIsNotSigned { get; } = new NoDataValidationIssue(ValidationIssueCode.PackageIsNotSigned);
+        public static ValidationIssue PackageIsSignedWithUnauthorizedCertificate { get; }
 
         /// <summary>
         /// The map of issue codes to the type that represents the issues. The types MUST extend <see cref="ValidationIssue"/>.
@@ -24,6 +25,7 @@ namespace NuGet.Services.Validation.Issues
         internal static readonly IReadOnlyDictionary<ValidationIssueCode, Type> IssueCodeTypes = new Dictionary<ValidationIssueCode, Type>
         {
             { ValidationIssueCode.ClientSigningVerificationFailure, GetIssueType<ClientSigningVerificationFailure>() },
+            { ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, GetIssueType<UnauthorizedCertificateFailure>() },
 #pragma warning disable 618
             { ValidationIssueCode.ObsoleteTesting, GetIssueType<ObsoleteTestingIssue>() }
 #pragma warning restore 618
@@ -61,7 +63,7 @@ namespace NuGet.Services.Validation.Issues
             {
                 return Unknown;
             }
-            
+
             try
             {
                 var issue = JsonConvert.DeserializeObject(data, deserializationType) as ValidationIssue;

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -17,7 +17,6 @@ namespace NuGet.Services.Validation.Issues
         public static ValidationIssue OnlySignatureFormatVersion1Supported { get; } = new NoDataValidationIssue(ValidationIssueCode.OnlySignatureFormatVersion1Supported);
         public static ValidationIssue AuthorCounterSignaturesNotSupported { get; } = new NoDataValidationIssue(ValidationIssueCode.AuthorCounterSignaturesNotSupported);
         public static ValidationIssue PackageIsNotSigned { get; } = new NoDataValidationIssue(ValidationIssueCode.PackageIsNotSigned);
-        public static ValidationIssue PackageIsSignedWithUnauthorizedCertificate { get; }
 
         /// <summary>
         /// The map of issue codes to the type that represents the issues. The types MUST extend <see cref="ValidationIssue"/>.

--- a/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
@@ -21,6 +21,7 @@ namespace NuGet.Services.Validation
             { 6, ValidationIssueCode.OnlySignatureFormatVersion1Supported },
             { 7, ValidationIssueCode.AuthorCounterSignaturesNotSupported },
             { 8, ValidationIssueCode.PackageIsNotSigned },
+            { 9, ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate },
 #pragma warning disable 618
             { 9999, ValidationIssueCode.ObsoleteTesting },
 #pragma warning restore 618

--- a/tests/NuGet.Services.Validation.Issues.Tests/Strings.Designer.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/Strings.Designer.cs
@@ -86,5 +86,14 @@ namespace NuGet.Services.Validation.Issues.Tests {
                 return ResourceManager.GetString("ObsoleteTestingIssueJson", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;t&quot;:&quot;thumbprint&quot;}.
+        /// </summary>
+        internal static string UnauthorizedCertificateFailureIssueJson {
+            get {
+                return ResourceManager.GetString("UnauthorizedCertificateFailureIssueJson", resourceCulture);
+            }
+        }
     }
 }

--- a/tests/NuGet.Services.Validation.Issues.Tests/Strings.resx
+++ b/tests/NuGet.Services.Validation.Issues.Tests/Strings.resx
@@ -126,4 +126,7 @@
   <data name="ObsoleteTestingIssueJson" xml:space="preserve">
     <value>{"A":"Hello","B":123}</value>
   </data>
+  <data name="UnauthorizedCertificateFailureIssueJson" xml:space="preserve">
+    <value>{"t":"thumbprint"}</value>
+  </data>
 </root>

--- a/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
@@ -73,6 +73,19 @@ namespace NuGet.Services.Validation.Issues.Tests
                 // Assert
                 Assert.Equal(Strings.ClientSigningVerificationFailureIssueJson, result);
             }
+
+            [Fact]
+            public void UnauthorizedCertificateFailureSerialization()
+            {
+                // Arrange
+                var signedError = new UnauthorizedCertificateFailure("thumbprint");
+
+                // Act
+                var result = signedError.Serialize();
+
+                // Assert
+                Assert.Equal(Strings.UnauthorizedCertificateFailureIssueJson, result);
+            }
         }
 
         public class TheDeserializeMethod
@@ -193,6 +206,21 @@ namespace NuGet.Services.Validation.Issues.Tests
                 Assert.Equal(ValidationIssueCode.ClientSigningVerificationFailure, result.IssueCode);
                 Assert.Equal("NU3008", result.ClientCode);
                 Assert.Equal("The package integrity check failed.", result.ClientMessage);
+            }
+
+            [Fact]
+            public void UnauthorizedCertificateFailureDeserialization()
+            {
+                // Arrange
+                var validationIssue = CreatePackageValidationIssue(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, Strings.UnauthorizedCertificateFailureIssueJson);
+
+                // Act
+                var result = ValidationIssue.Deserialize(validationIssue.IssueCode, validationIssue.Data) as UnauthorizedCertificateFailure;
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, result.IssueCode);
+                Assert.Equal("thumbprint", result.Sha1Thumbprint);
             }
 
             private PackageValidationIssue CreatePackageValidationIssue(ValidationIssueCode issueCode, string data)


### PR DESCRIPTION
Add a new issue for the signature validation failure when a package is signed with a certificate that is not known to the package's signing owner(s).