### PR TITLE
Missed update to IValidationEntitiesContext

### DIFF
--- a/src/NuGet.Services.Validation/Entities/IValidationContext.cs
+++ b/src/NuGet.Services.Validation/Entities/IValidationContext.cs
@@ -19,7 +19,8 @@ namespace NuGet.Services.Validation
         IDbSet<EndCertificateValidation> CertificateValidations { get; }
         IDbSet<CertificateChainLink> CertificateChainLinks { get; }
         IDbSet<ParentCertificate> ParentCertificates { get; }
-        IDbSet<PackageCompatibilityIssue> PackageCompatibilityIssues {get;}
+        IDbSet<PackageCompatibilityIssue> PackageCompatibilityIssues { get; }
+        IDbSet<ScanOperationState> ScanOperationStates { get; }
 
         Task<int> SaveChangesAsync();
     }


### PR DESCRIPTION
#151 added `ScanOperationStates` to implementation, but wasn't added to the interface.
 