### PR TITLE
Allow deferred connections from SqlConnectionFactory

### DIFF
--- a/src/NuGet.Services.Sql/ISqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/ISqlConnectionFactory.cs
@@ -15,8 +15,13 @@ namespace NuGet.Services.Sql
         string InitialCatalog { get; }
 
         /// <summary>
-        /// Create and open a connection to the SqlServer database.
+        /// Create a connection to the SqlServer database.
         /// </summary>
         Task<SqlConnection> CreateAsync();
+
+        /// <summary>
+        /// Create and open a connection to the SqlServer database.
+        /// </summary>
+        Task<SqlConnection> OpenAsync();
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/1472

Related: https://github.com/NuGet/NuGetGallery/pull/6063

Will use `CreateAsync` when used with EF so that the open can be deferred and controlled fully by the `DbContext`.