### PR TITLE
Service bus telemetry

### DIFF
--- a/src/NuGet.Services.ServiceBus/ISubscriptionProcessorTelemetryService.cs
+++ b/src/NuGet.Services.ServiceBus/ISubscriptionProcessorTelemetryService.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.ServiceBus
         /// scheduled delivery time set to T+S and was actually received at T+S+L, the reported
         /// value is going to be: (T+S+L) - (T+S) = L.
         /// </remarks>
-        void TrackMessageDeliveryLag(TimeSpan deliveryLag);
+        void TrackMessageDeliveryLag<TMessage>(TimeSpan deliveryLag);
 
         /// <summary>
         /// Tracks the time difference between the scheduled enqueue time and actual enqueue time.
@@ -29,6 +29,6 @@ namespace NuGet.Services.ServiceBus
         /// This time being noticeably greater than zero might indicate perf issues on Service Bus
         /// side, if we ever to see any.
         /// </remarks>
-        void TrackEnqueueLag(TimeSpan enqueueLag);
+        void TrackEnqueueLag<TMessage>(TimeSpan enqueueLag);
     }
 }

--- a/src/NuGet.Services.ServiceBus/ISubscriptionProcessorTelemetryService.cs
+++ b/src/NuGet.Services.ServiceBus/ISubscriptionProcessorTelemetryService.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.ServiceBus
+{
+    /// <summary>
+    /// Interface for the telemetry emitted by <see cref="SubscriptionProcessor{TMessage}"/>.
+    /// </summary>
+    public interface ISubscriptionProcessorTelemetryService
+    {
+        /// <summary>
+        /// Tracks the time difference between the time a message was received and the time
+        /// it was scheduled to be enqueued.
+        /// </summary>
+        /// <remarks>
+        /// Scheduled enqueueing set by <see cref="IBrokeredMessage.ScheduledEnqueueTimeUtc"/> 
+        /// affects the reported time: if message was enqueued by the code at time T, had
+        /// scheduled delivery time set to T+S and was actually received at T+S+L, the reported
+        /// value is going to be: (T+S+L) - (T+S) = L.
+        /// </remarks>
+        void TrackMessageDeliveryLag(TimeSpan deliveryLag);
+
+        /// <summary>
+        /// Tracks the time difference between the scheduled enqueue time and actual enqueue time.
+        /// </summary>
+        /// <remarks>
+        /// This time being noticeably greater than zero might indicate perf issues on Service Bus
+        /// side, if we ever to see any.
+        /// </remarks>
+        void TrackEnqueueLag(TimeSpan enqueueLag);
+    }
+}

--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -46,6 +46,7 @@
     <Compile Include="IBrokeredMessageSerializer.cs" />
     <Compile Include="IMessageHandler.cs" />
     <Compile Include="ISubscriptionProcessor.cs" />
+    <Compile Include="ISubscriptionProcessorTelemetryService.cs" />
     <Compile Include="OnMessageOptionsWrapper.cs" />
     <Compile Include="ScopedMessageHandler.cs" />
     <Compile Include="SubscriptionProcessor.cs" />
@@ -53,6 +54,7 @@
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="SchemaAttribute.cs" />
     <Compile Include="SubscriptionClientWrapper.cs" />
+    <Compile Include="SubscriptionProcessorNoTelemetryService.cs" />
     <Compile Include="TopicClientWrapper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -168,6 +168,8 @@ namespace NuGet.Services.ServiceBus
             try
             {
                 _telemetryService.TrackMessageDeliveryLag(DateTimeOffset.UtcNow - brokeredMessage.ScheduledEnqueueTimeUtc);
+                // we expect the "enqueue lag" to be zero or really close to zero pretty much all the time, logging it just in case it is not
+                // and for historical perspective if we need one.
                 _telemetryService.TrackEnqueueLag(brokeredMessage.EnqueuedTimeUtc - brokeredMessage.ScheduledEnqueueTimeUtc);
             }
             catch { }

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -33,6 +33,7 @@ namespace NuGet.Services.ServiceBus
         /// <param name="client">The client used to receive messages from the subscription.</param>
         /// <param name="serializer">The serializer used to deserialize received messages.</param>
         /// <param name="handler">The handler used to handle received messages.</param>
+        /// <param name="telemetryService">The telemetry service reference to which this class submits telemetry.</param>
         /// <param name="logger">The logger used to record debug information.</param>
         public SubscriptionProcessor(
             ISubscriptionClient client,

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -24,7 +24,6 @@ namespace NuGet.Services.ServiceBus
 
         private bool _running;
         private int _numberOfMessagesInProgress;
-        private Action<TimeSpan> _messageLagCallback;
 
         public int NumberOfMessagesInProgress => _numberOfMessagesInProgress;
 
@@ -50,7 +49,6 @@ namespace NuGet.Services.ServiceBus
 
             _running = false;
             _numberOfMessagesInProgress = 0;
-            _messageLagCallback = null;
         }
 
         public void Start()
@@ -165,14 +163,10 @@ namespace NuGet.Services.ServiceBus
 
         private void TrackMessageLags(IBrokeredMessage brokeredMessage)
         {
-            try
-            {
-                _telemetryService.TrackMessageDeliveryLag(DateTimeOffset.UtcNow - brokeredMessage.ScheduledEnqueueTimeUtc);
-                // we expect the "enqueue lag" to be zero or really close to zero pretty much all the time, logging it just in case it is not
-                // and for historical perspective if we need one.
-                _telemetryService.TrackEnqueueLag(brokeredMessage.EnqueuedTimeUtc - brokeredMessage.ScheduledEnqueueTimeUtc);
-            }
-            catch { }
+            _telemetryService.TrackMessageDeliveryLag<TMessage>(DateTimeOffset.UtcNow - brokeredMessage.ScheduledEnqueueTimeUtc);
+            // we expect the "enqueue lag" to be zero or really close to zero pretty much all the time, logging it just in case it is not
+            // and for historical perspective if we need one.
+            _telemetryService.TrackEnqueueLag<TMessage>(brokeredMessage.EnqueuedTimeUtc - brokeredMessage.ScheduledEnqueueTimeUtc);
         }
     }
 }

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessorNoTelemetryService.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessorNoTelemetryService.cs
@@ -11,11 +11,11 @@ namespace NuGet.Services.ServiceBus
     /// </summary>
     public class SubscriptionProcessorNoTelemetryService : ISubscriptionProcessorTelemetryService
     {
-        public void TrackMessageDeliveryLag(TimeSpan deliveryLag)
+        public void TrackMessageDeliveryLag<TMessage>(TimeSpan deliveryLag)
         {
         }
 
-        public void TrackEnqueueLag(TimeSpan enqueueLag)
+        public void TrackEnqueueLag<TMessage>(TimeSpan enqueueLag)
         {
 
         }

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessorNoTelemetryService.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessorNoTelemetryService.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.ServiceBus
+{
+    /// <summary>
+    /// The implementation of the <see cref="ISubscriptionProcessorTelemetryService"/>
+    /// that does not send any telemetry.
+    /// </summary>
+    public class SubscriptionProcessorNoTelemetryService : ISubscriptionProcessorTelemetryService
+    {
+        public void TrackMessageDeliveryLag(TimeSpan deliveryLag)
+        {
+        }
+
+        public void TrackEnqueueLag(TimeSpan enqueueLag)
+        {
+
+        }
+    }
+}

--- a/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
@@ -166,9 +166,9 @@ namespace NuGet.Services.ServiceBus.Tests
                 await onMessageAsync(_brokeredMessage.Object);
 
                 _telemetryService
-                    .Verify(ts => ts.TrackMessageDeliveryLag(It.IsAny<TimeSpan>()), Times.Once);
+                    .Verify(ts => ts.TrackMessageDeliveryLag<TestMessage>(It.IsAny<TimeSpan>()), Times.Once);
                 _telemetryService
-                    .Verify(ts => ts.TrackEnqueueLag(It.IsAny<TimeSpan>()), Times.Once);
+                    .Verify(ts => ts.TrackEnqueueLag<TestMessage>(It.IsAny<TimeSpan>()), Times.Once);
             }
         }
 

--- a/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/SubscriptionProcessorFacts.cs
@@ -149,6 +149,12 @@ namespace NuGet.Services.ServiceBus.Tests
                 _handler.Verify(h => h.HandleAsync(It.IsAny<TestMessage>()), Times.Once);
                 _brokeredMessage.Verify(m => m.CompleteAsync(), Times.Never);
             }
+
+            [Fact]
+            public async Task TracksMessageLag()
+            {
+
+            }
         }
 
         public class TheShutdownAsyncMethod : Base
@@ -205,6 +211,7 @@ namespace NuGet.Services.ServiceBus.Tests
             protected readonly Mock<ISubscriptionClient> _client;
             protected readonly Mock<IBrokeredMessageSerializer<TestMessage>> _serializer;
             protected readonly Mock<IMessageHandler<TestMessage>> _handler;
+            protected readonly Mock<ISubscriptionProcessorTelemetryService> _telemetryService;
             protected readonly SubscriptionProcessor<TestMessage> _target;
 
             protected readonly Mock<IBrokeredMessage> _brokeredMessage;
@@ -214,6 +221,7 @@ namespace NuGet.Services.ServiceBus.Tests
                 _client = new Mock<ISubscriptionClient>();
                 _serializer = new Mock<IBrokeredMessageSerializer<TestMessage>>();
                 _handler = new Mock<IMessageHandler<TestMessage>>();
+                _telemetryService = new Mock<ISubscriptionProcessorTelemetryService>();
 
                 _brokeredMessage = new Mock<IBrokeredMessage>();
 
@@ -223,6 +231,7 @@ namespace NuGet.Services.ServiceBus.Tests
                     _client.Object,
                     _serializer.Object,
                     _handler.Object,
+                    _telemetryService.Object,
                     logger.Object);
             }
         }


### PR DESCRIPTION
Added the `ISubscriptionProcessorTelemetryService` that would allow to export two metrics from the Service Bus client:
* Message delivery lag - the time between when the message was supposed to be enqueued for delivery to the client and the actual delivery time. Larger (>~1 second) values of the metric would indicate congestion when processing service bus messages (i.e. we are receiving more messages than processing);
* Enqueue lag - the time between when the message was supposed to be enqueued for delivery and actual enqueuing time. The values greater than zero here would indicate some sort of issues on Service Bus side, so I expect this metric to be zero or near-zero 100% of the time. But if it is not, it would hopefully save us time on debugging some funny issues.

Since it's a breaking change in a library, the default implementation of the new interface was added that does nothing, but would allow quick recovery from the breaking change to the "as before" state if needed. Otherwise callers are to proper implement the interface so the metrics are actually saved.