### PR TITLE
Add the Killswitch client

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -62,6 +62,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Sql", "src\N
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Sql.Tests", "tests\NuGet.Services.Sql.Tests\NuGet.Services.Sql.Tests.csproj", "{FA2B3447-7242-495F-A8E1-D94181C0C9A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.KillSwitch", "src\NuGet.Services.KillSwitch\NuGet.Services.KillSwitch.csproj", "{BC8D8216-8A19-4402-9DA3-238D0162B0A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Killswitch.Tests", "tests\NuGet.Services.Killswitch.Tests\NuGet.Services.Killswitch.Tests.csproj", "{4F73955E-3A98-4403-8BBE-43271FED1CA3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -168,6 +172,14 @@ Global
 		{FA2B3447-7242-495F-A8E1-D94181C0C9A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA2B3447-7242-495F-A8E1-D94181C0C9A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA2B3447-7242-495F-A8E1-D94181C0C9A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC8D8216-8A19-4402-9DA3-238D0162B0A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC8D8216-8A19-4402-9DA3-238D0162B0A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC8D8216-8A19-4402-9DA3-238D0162B0A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC8D8216-8A19-4402-9DA3-238D0162B0A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F73955E-3A98-4403-8BBE-43271FED1CA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F73955E-3A98-4403-8BBE-43271FED1CA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F73955E-3A98-4403-8BBE-43271FED1CA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F73955E-3A98-4403-8BBE-43271FED1CA3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -198,6 +210,8 @@ Global
 		{E29F54DF-DFB8-4E27-940D-21ECCB9B6FC1} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{F5121B0A-669F-48BD-86DC-27C546D1A825} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{FA2B3447-7242-495F-A8E1-D94181C0C9A5} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
+		{BC8D8216-8A19-4402-9DA3-238D0162B0A6} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
+		{4F73955E-3A98-4403-8BBE-43271FED1CA3} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AA413DB0-5475-4B5D-A3AF-6323DA8D538B}

--- a/build.ps1
+++ b/build.ps1
@@ -72,8 +72,9 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\NuGet.Services.ServiceBus\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Validation\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Validation.Issues\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Sql\Properties\AssemblyInfo.g.cs"
-            
+            "$PSScriptRoot\src\NuGet.Services.Sql\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Killswitch\Properties\AssemblyInfo.g.cs"
+
         $versionMetadata | ForEach-Object {
             Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA
         }
@@ -105,8 +106,9 @@ Invoke-BuildStep 'Creating artifacts' { `
             "src\NuGet.Services.ServiceBus\NuGet.Services.ServiceBus.csproj", `
             "src\NuGet.Services.Validation\NuGet.Services.Validation.csproj", `
             "src\NuGet.Services.Validation.Issues\NuGet.Services.Validation.Issues.csproj", `
-            "src\NuGet.Services.Sql\NuGet.Services.Sql.csproj"
-            
+            "src\NuGet.Services.Sql\NuGet.Services.Sql.csproj", `
+            "src\NuGet.Services.Killswitch\NuGet.Services.Killswitch.csproj"
+
         $projects | ForEach-Object {
             New-Package (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -IncludeReferencedProjects -MSBuildVersion "15"
         }

--- a/src/NuGet.Services.KillSwitch/HttpKillswitchClient.cs
+++ b/src/NuGet.Services.KillSwitch/HttpKillswitchClient.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.KillSwitch
+{
+    /// <summary>
+    /// A killswitch service that queries an HTTP service periodically for the list of active killswitches.
+    /// </summary>
+    public class HttpKillswitchClient : IKillswitchClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly HttpKillswitchConfig _config;
+        private readonly ILogger<HttpKillswitchClient> _logger;
+
+        private int _started;
+        private KillswitchCache _cache;
+
+        public HttpKillswitchClient(
+            HttpClient httpClient,
+            HttpKillswitchConfig config,
+            ILogger<HttpKillswitchClient> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _started = 0;
+            _cache = null;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Ensure that this client has not already been started.
+            if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
+            {
+                _logger.LogError("The killswitch client has already been started!");
+
+                throw new InvalidOperationException("The killswitch client has already been started!");
+            }
+
+            // Prime the killswitch cache.
+            await RefreshAsync(cancellationToken);
+
+            // Refresh the killswitch cache on a background thread periodically.
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            Task.Run(async () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await Task.Delay(_config.RefreshInterval);
+                        await RefreshAsync(cancellationToken);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(0, e, "Failed to refresh the killswitch cache due to exception");
+                    }
+                }
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        }
+
+        public async Task RefreshAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _logger.LogInformation("Refreshing killswitches...");
+
+            var duration = Stopwatch.StartNew();
+            var response = await _httpClient.GetAsync(_config.KillswitchEndpoint, cancellationToken);
+            var content = await response.Content.ReadAsStringAsync();
+
+            var items = JsonConvert.DeserializeObject<List<string>>(content);
+
+            _cache = new KillswitchCache(items);
+
+            _logger.LogInformation("Refreshed killswitches after {ElapsedTime}", duration.Elapsed);
+        }
+
+        public bool IsActive(string name)
+        {
+            var cache = _cache;
+
+            if (cache == null)
+            {
+                _logger.LogError("Cannot check the killswitch {Name} as the client isn't started", name);
+
+                throw new InvalidOperationException("Cannot check the killswitch as the client isn't started");
+            }
+
+            if (cache.Staleness.Elapsed >= _config.MaximumStaleness)
+            {
+                _logger.LogError(
+                    "Failed to determine whether the killswitch {Name} is active as the client's cache is {Staleness} stale",
+                    name,
+                    cache.Staleness.Elapsed);
+
+                throw new InvalidOperationException("Reached maximum killswitch staleness threshold");
+            }
+
+            return cache.Items.Contains(name);
+        }
+
+        private class KillswitchCache
+        {
+            public KillswitchCache(List<string> items)
+            {
+                Staleness = Stopwatch.StartNew();
+                Items = new HashSet<string>(items, StringComparer.OrdinalIgnoreCase);
+            }
+
+            public Stopwatch Staleness { get; }
+            public HashSet<string> Items { get; }
+        }
+    }
+}

--- a/src/NuGet.Services.KillSwitch/HttpKillswitchConfig.cs
+++ b/src/NuGet.Services.KillSwitch/HttpKillswitchConfig.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.KillSwitch
+{
+    /// <summary>
+    /// The configuration for <see cref="HttpKillswitchClient"/>.
+    /// </summary>
+    public class HttpKillswitchConfig
+    {
+        /// <summary>
+        /// The REST endpoint that contains the list of activated killswitch.
+        /// </summary>
+        public Uri KillswitchEndpoint { get; set; }
+
+        /// <summary>
+        /// How frequently the endpoint should be queried.
+        /// </summary>
+        public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// The maximum allowed staleness by <see cref="HttpKillswitchClient.IsActive(string)"/>.
+        /// The method will throw if this threshold is reached.
+        /// </summary>
+        public TimeSpan MaximumStaleness { get; set; } = TimeSpan.FromMinutes(20);
+    }
+}

--- a/src/NuGet.Services.KillSwitch/IKillswitchClient.cs
+++ b/src/NuGet.Services.KillSwitch/IKillswitchClient.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KillSwitch
+{
+    /// <summary>
+    /// Use killswitches to dynamically disable features in your service.
+    /// </summary>
+    public interface IKillswitchClient
+    {
+        /// <summary>
+        /// Start tracking the killswitches. This method can be called only once per instance.
+        /// </summary>
+        /// <param name="cancellationToken">Token to stop tracking the killswitches.</param>
+        /// <returns>A task that completes after the killswitches have been loaded.</returns>
+        Task StartAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Force a refresh of the list of activated killswitches. This can be called as frequently
+        /// as desired, regardless of whether <see cref="StartAsync(CancellationToken)"/> has been called.
+        /// </summary>
+        /// <param name="cancellationToken">Cancel the refresh operation.</param>
+        /// <returns>A task that completes when the known killswitches have been refreshed.</returns>
+        Task RefreshAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Check whether the killswitch is known to be active. The list of known activated killswitches MUST be
+        /// loaded (through either <see cref="StartAsync(CancellationToken)"/> or <see cref="RefreshAsync"/>) prior
+        /// to calling this method. If you'd like to guarantee the result isn't stale, call <see cref="RefreshAsync"/>
+        /// prior to calling this method.
+        /// </summary>
+        /// <param name="name">The name of the killswitch.</param>
+        /// <returns>True if the killswitch is known to be active.</returns>
+        bool IsActive(string name);
+    }
+}

--- a/src/NuGet.Services.KillSwitch/NuGet.Services.KillSwitch.csproj
+++ b/src/NuGet.Services.KillSwitch/NuGet.Services.KillSwitch.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BC8D8216-8A19-4402-9DA3-238D0162B0A6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.KillSwitch</RootNamespace>
+    <AssemblyName>NuGet.Services.KillSwitch</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IKillswitchClient.cs" />
+    <Compile Include="HttpKillswitchConfig.cs" />
+    <Compile Include="HttpKillswitchClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\build\sign.targets" />
+</Project>

--- a/src/NuGet.Services.KillSwitch/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.KillSwitch/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.Services.Killswitch")]
+[assembly: AssemblyDescription("Disable NuGet service features at runtime")]
+[assembly: AssemblyProduct("NuGet.Services.Killswitch")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2018")]
+[assembly: ComVisible(false)]
+[assembly: Guid("bc8d8216-8a19-4402-9da3-238d0162b0a6")]
+[assembly: AssemblyCompany(".NET Foundation")]
+
+// Assembly version info is set at build time

--- a/src/NuGet.Services.KillSwitch/project.json
+++ b/src/NuGet.Services.KillSwitch/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "dependencies": {
+    "System.Net.Http": "4.3.3",
+    "Microsoft.Extensions.Logging": "1.1.2",
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "frameworks": {
+    "net45": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}

--- a/tests/NuGet.Services.Killswitch.Tests/HttpKillswitchClientFacts.cs
+++ b/tests/NuGet.Services.Killswitch.Tests/HttpKillswitchClientFacts.cs
@@ -1,0 +1,369 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuGet.Services.KillSwitch;
+using Xunit;
+
+namespace NuGet.Services.Killswitch.Tests
+{
+    public class HttpKillswitchClientFacts
+    {
+        public class TheStartAsyncMethod : FactsBase
+        {
+            public TheStartAsyncMethod(KillswitchIntegrationTestFixture fixture) : base(fixture) { }
+
+            [Fact]
+            public async Task StartLoadsKillswitches()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+
+                    tokenSource.Cancel();
+                }
+            }
+
+            [Fact]
+            public async Task ThrowsIfAlreadyStarted()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+
+                    var e = await Assert.ThrowsAsync<InvalidOperationException>(() => target.StartAsync(CancellationToken.None));
+
+                    Assert.Equal("The killswitch client has already been started!", e.Message);
+
+                    tokenSource.Cancel();
+                }
+            }
+
+            [Fact]
+            public async Task ThrowsOnMalformedInitialResponse()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "Foo.Bar";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await Assert.ThrowsAsync<JsonReaderException>(() => target.StartAsync(tokenSource.Token));
+
+                    var e = Assert.Throws<InvalidOperationException>(() => target.IsActive("Foo.Bar"));
+
+                    Assert.Equal("Cannot check the killswitch as the client isn't started", e.Message);
+
+                    tokenSource.Cancel();
+                }
+            }
+
+            [Fact]
+            public async Task StartRefreshesKillswitchesInBackground()
+            {
+                // Arrange
+                var config = new HttpKillswitchConfig { RefreshInterval = TimeSpan.FromMilliseconds(10) };
+
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync(config);
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    testServer.Response = "[\"hello.world\"]";
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    Assert.False(target.IsActive("Foo.Bar"));
+                    Assert.True(target.IsActive("Hello.World"));
+
+                    tokenSource.Cancel();
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotThrowOnMalformedSubsequentResponses()
+            {
+                // Arrange
+                var config = new HttpKillswitchConfig { RefreshInterval = TimeSpan.FromMilliseconds(10) };
+
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync(config);
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    testServer.Response = "Hello.World";
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    testServer.Response = "[\"Hello.World\"]";
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    Assert.False(target.IsActive("Foo.Bar"));
+                    Assert.True(target.IsActive("Hello.World"));
+
+                    tokenSource.Cancel();
+                }
+            }
+
+            [Fact]
+            public async Task BackgroundRefreshRespectsCancellationToken()
+            {
+                // Arrange
+                var config = new HttpKillswitchConfig { RefreshInterval = TimeSpan.FromMilliseconds(10) };
+
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync(config);
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    tokenSource.Cancel();
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    testServer.Response = "[\"Hello.World\"]";
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+                }
+            }
+        }
+
+        public class TheRefreshAsyncMethod : FactsBase
+        {
+            public TheRefreshAsyncMethod(KillswitchIntegrationTestFixture fixture) : base(fixture) { }
+
+            [Fact]
+            public async Task ThrowsIfCancelled()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    // Act & Assert
+                    await target.RefreshAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+
+                    tokenSource.Cancel();
+
+                    await Assert.ThrowsAsync<OperationCanceledException>(() => target.RefreshAsync(tokenSource.Token));
+                }
+            }
+
+            [Fact]
+            public async Task Refreshes()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                await target.RefreshAsync(CancellationToken.None);
+
+                Assert.True(target.IsActive("Foo.Bar"));
+            }
+
+            [Fact]
+            public async Task IfServerResponseIsMalformed_Throws()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "Foo.Bar";
+
+                // Act & Assert
+                await Assert.ThrowsAsync<JsonReaderException>(() => target.RefreshAsync(CancellationToken.None));
+
+                var e = Assert.Throws<InvalidOperationException>(() => target.IsActive("Foo.Bar"));
+
+                Assert.Equal("Cannot check the killswitch as the client isn't started", e.Message);
+            }
+
+            [Fact]
+            public async Task ManualRefreshAllowedAfterStart()
+            {
+                // Arrange
+                var config = new HttpKillswitchConfig { RefreshInterval = TimeSpan.FromDays(10) };
+
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync(config);
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    testServer.Response = "[\"hello.world\"]";
+
+                    await target.RefreshAsync(CancellationToken.None);
+
+                    Assert.False(target.IsActive("Foo.Bar"));
+                    Assert.True(target.IsActive("Hello.World"));
+
+                    tokenSource.Cancel();
+                }
+            }
+        }
+
+        public class TheIsActiveMethod : FactsBase
+        {
+            public TheIsActiveMethod(KillswitchIntegrationTestFixture fixture) : base(fixture) { }
+
+            [Fact]
+            public async Task ThrowsIfKillswitchesNotLoaded()
+            {
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                var e = Assert.Throws<InvalidOperationException>(() => target.IsActive("Foo.Bar"));
+
+                Assert.Equal("Cannot check the killswitch as the client isn't started", e.Message);
+            }
+
+            [Fact]
+            public async Task ReturnsTrueForActiveKillswitches()
+            {
+                // Arrange
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync();
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                await target.RefreshAsync(CancellationToken.None);
+
+                Assert.True(target.IsActive("Foo.Bar"));
+                Assert.True(target.IsActive("foo.bar"));
+                Assert.False(target.IsActive("Hello.World"));
+
+                testServer.Response = "[\"hello.world\"]";
+
+                await target.RefreshAsync(CancellationToken.None);
+
+                Assert.False(target.IsActive("Foo.Bar"));
+                Assert.False(target.IsActive("foo.bar"));
+                Assert.True(target.IsActive("Hello.World"));
+
+                testServer.Response = "[]";
+
+                await target.RefreshAsync(CancellationToken.None);
+
+                Assert.False(target.IsActive("Foo.Bar"));
+                Assert.False(target.IsActive("foo.bar"));
+                Assert.False(target.IsActive("Hello.World"));
+            }
+
+            [Fact]
+            public async Task ThrowsIfPastStalenessThreshold()
+            {
+                // Arrange
+                var config = new HttpKillswitchConfig
+                {
+                    RefreshInterval = TimeSpan.FromMilliseconds(10),
+                    MaximumStaleness = TimeSpan.FromMilliseconds(100),
+                };
+
+                var testServer = await _fixture.GetTestServerAsync();
+                var target = await _fixture.GetClientAsync(config);
+
+                testServer.Response = "[\"Foo.Bar\"]";
+
+                // Act & Assert
+                using (var tokenSource = new CancellationTokenSource())
+                {
+                    await target.StartAsync(tokenSource.Token);
+
+                    Assert.True(target.IsActive("Foo.Bar"));
+                    Assert.False(target.IsActive("Hello.World"));
+
+                    testServer.Response = "This response fails all refresh attempts thereby making the cache stale";
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    var e = Assert.Throws<InvalidOperationException>(() => target.IsActive("Foo.Bar"));
+
+                    Assert.Equal("Reached maximum killswitch staleness threshold", e.Message);
+
+                    tokenSource.Cancel();
+                }
+            }
+        }
+
+        [Collection(KillswitchIntegrationTestCollection.Name)]
+        public class FactsBase
+        {
+            protected readonly KillswitchIntegrationTestFixture _fixture;
+
+            public FactsBase(KillswitchIntegrationTestFixture fixture)
+            {
+                _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Killswitch.Tests/NuGet.Services.Killswitch.Tests.csproj
+++ b/tests/NuGet.Services.Killswitch.Tests/NuGet.Services.Killswitch.Tests.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F73955E-3A98-4403-8BBE-43271FED1CA3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.Killswitch.Tests</RootNamespace>
+    <AssemblyName>NuGet.Services.Killswitch.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="HttpKillswitchClientFacts.cs" />
+    <Compile Include="Support\KillswitchIntegrationTestCollection.cs" />
+    <Compile Include="Support\KillswitchIntegrationTestFixture.cs" />
+    <Compile Include="Support\KillswitchTestServer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.KillSwitch\NuGet.Services.KillSwitch.csproj">
+      <Project>{bc8d8216-8a19-4402-9da3-238d0162b0a6}</Project>
+      <Name>NuGet.Services.KillSwitch</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/NuGet.Services.Killswitch.Tests/Properties/AssemblyInfo.cs
+++ b/tests/NuGet.Services.Killswitch.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.Services.Killswitch.Tests")]
+[assembly: AssemblyDescription("Unit tests for Killswitch library")]
+[assembly: AssemblyProduct("NuGet.Services.Killswitch.Tests")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2018")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchIntegrationTestCollection.cs
+++ b/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchIntegrationTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.Services.Killswitch.Tests
+{
+    [CollectionDefinition(Name)]
+    public class KillswitchIntegrationTestCollection : ICollectionFixture<KillswitchIntegrationTestFixture>
+    {
+        public const string Name = "Killswitch integration test collection";
+    }
+}

--- a/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchIntegrationTestFixture.cs
+++ b/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchIntegrationTestFixture.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Services.KillSwitch;
+
+namespace NuGet.Services.Killswitch.Tests
+{
+    public class KillswitchIntegrationTestFixture : IDisposable
+    {
+        private readonly HttpClient _httpClient;
+        private readonly Lazy<Task<KillswitchTestServer>> _testServer;
+
+        public KillswitchIntegrationTestFixture()
+        {
+            _httpClient = new HttpClient();
+            _testServer = new Lazy<Task<KillswitchTestServer>>(KillswitchTestServer.CreateAsync);
+        }
+
+        public HttpClient GetHttpClient() => _httpClient;
+        public Task<KillswitchTestServer> GetTestServerAsync() => _testServer.Value;
+
+        public async Task<HttpKillswitchClient> GetClientAsync(HttpKillswitchConfig config = null)
+        {
+            var testServer = await GetTestServerAsync();
+
+            config = config ?? new HttpKillswitchConfig();
+            config.KillswitchEndpoint = testServer.Url;
+
+            return new HttpKillswitchClient(_httpClient, config, Mock.Of<ILogger<HttpKillswitchClient>>());
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+
+            if (_testServer.IsValueCreated)
+            {
+                _testServer.Value.Result.Dispose();
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchTestServer.cs
+++ b/tests/NuGet.Services.Killswitch.Tests/Support/KillswitchTestServer.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Test.Server;
+using Test.Utility;
+
+namespace NuGet.Services.Killswitch.Tests
+{
+    // Based off of https://github.com/NuGet/NuGet.Client/blob/dev/test/TestUtilities/Test.Utility/Signing/SigningTestServer.cs
+    public class KillswitchTestServer
+    {
+        public const string DefaultResponse = "[]";
+
+        private readonly HttpListener _listener;
+        private bool _isDisposed;
+
+        private KillswitchTestServer(HttpListener listener, Uri url)
+        {
+            _listener = listener;
+
+            Url = url;
+            Response = DefaultResponse;
+        }
+
+        public Uri Url { get; }
+
+        public string Response { get; set; }
+
+        public static Task<KillswitchTestServer> CreateAsync()
+        {
+            var portReserver = new PortReserver();
+
+            return portReserver.ExecuteAsync(CreateInternalAsync, CancellationToken.None);
+        }
+
+        private static Task<KillswitchTestServer> CreateInternalAsync(int port, CancellationToken token)
+        {
+            var url = new Uri($"http://127.0.0.1:{port}/");
+            var httpListener = new HttpListener();
+
+            httpListener.IgnoreWriteExceptions = true;
+            httpListener.Prefixes.Add(url.OriginalString);
+            httpListener.Start();
+
+            var server = new KillswitchTestServer(httpListener, url);
+
+            using (var taskStartedEvent = new ManualResetEventSlim())
+            {
+                Task.Factory.StartNew(() => server.HandleRequest(taskStartedEvent, token));
+
+                taskStartedEvent.Wait(token);
+            }
+
+            return Task.FromResult(server);
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                _listener.Stop();
+                _listener.Abort();
+
+                GC.SuppressFinalize(this);
+
+                _isDisposed = true;
+            }
+        }
+
+        private void HandleRequest(ManualResetEventSlim mutex, CancellationToken cancellationToken)
+        {
+            mutex.Set();
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var context = _listener.GetContext();
+
+                    byte[] responseBuffer = Encoding.UTF8.GetBytes(Response);
+
+                    context.Response.ContentType = "text/plain";
+                    context.Response.ContentLength64 = responseBuffer.Length;
+
+                    using (var writer = new BinaryWriter(context.Response.OutputStream))
+                    {
+                        writer.Write(responseBuffer);
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+                catch (HttpListenerException ex)
+                {
+                    if (ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_HANDLE ||
+                        ex.ErrorCode == ErrorConstants.ERROR_INVALID_FUNCTION ||
+                        RuntimeEnvironmentHelper.IsMono && ex.ErrorCode == ErrorConstants.ERROR_OPERATION_ABORTED_MONO)
+                    {
+                        return;
+                    }
+
+                    Console.WriteLine($"Unexpected error code: {ex.ErrorCode}. Exception: {ex}");
+
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Killswitch.Tests/project.json
+++ b/tests/NuGet.Services.Killswitch.Tests/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "dependencies": {
+    "System.Net.Http": "4.3.3",
+    "Moq": "4.5.23",
+    "SerilogTraceListener": "2.0.10027",
+    "xunit": "2.3.1",
+    "Test.Utility": "4.8.0-preview4.5289"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}


### PR DESCRIPTION
Killswitches allow you to turn off services' features remotely. This will be used to turn off the revalidation job if it causes pressure on the ingestion pipeline. The API is simple:

```csharp
if (!_killswitchClient.IsActive("MyService.MyFeature"))
{
  _logger.LogWarning("My feature is disabled, don't do anything!");
  return;
}
```

Like the [`ITelemetryClient`](https://github.com/NuGet/ServerCommon/blob/master/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs), services are expected to wrap the `IKillswitchClient` with higher-level abstractions. For example:

```csharp
if (!_killswitchService.ShouldEnqueueRevalidation())
{
  _logger.LogWarning("Revalidations have been disabled!");
  return;
}
```

# Killswitch Endpoint

Killswitches work by polling an endpoint that returns a JSON list of activated killswitches:

```json
[
  "Revalidation.Enqueue",
  "Gallery.SymbolUploads"
  "Orchestrator.RepositorySigning"
]
```

This endpoint will be a JSON file hosted on Azure Blob Storage. An admin panel will be created on the Gallery to modify this file.

# Design Decisions

## Client uses HTTP endpoint instead of Azure Blob Storage

The fact that we use blob storage on the backend is an implementation detail. With blob storage, we'd need to add storage credentials to all services, which would increase the cost to on-board. As for privacy concerns, we could make the killswitch blob private but generate a URI with read-only access for services to consume.

Lastly, an HTTP implementation can support a push model through long-polling. As far as I know, this cannot be done using Azure Blob Storage.

## Background Refresh

In this implementation, `IsActive` does not refresh the killswitch cache. Instead, a background task refreshes the cache periodically (every 5 minutes by default). This lets consumers of the killswitch client call `IsActive` as frequently as they'd like, including in hot paths. 

# Compared to Gallery's [`ContentObjectService`](https://github.com/NuGet/NuGetGallery/blob/4622ebed4e10a25987adc41cc94fe6dab9d57508/src/NuGetGallery/Services/ContentObjectService.cs)

The `HttpKillswitchClient` is very similar to the `ContentObjectService`:

* Both refresh their state in the background
* Both store their state as JSON on an endpoint
* Both allow fast lookups of the currently cached values

The differences are:

* The `ContentObjectService` gives you high-level objects, allowing you to build complex feature flag logic. The `HttpKillswitchClient` can only determine whether a features should be on or off
* To add a new feature, the `ContentObjectService` requires code changes in both the Gallery as well as the service that owns the feature
* The `ContentObjectService` uses APIs specific to ASP.NET for background refreshes, and cannot be used by jobs (see [this](https://github.com/NuGet/NuGetGallery/blob/4622ebed4e10a25987adc41cc94fe6dab9d57508/src/NuGetGallery/App_Start/OwinStartup.cs#L71))
* The `ContentObjectService` fails silently if the latest settings cannot be fetched/parsed
* The `ContentObjectService` depends on Azure Blob Storage

Part of https://github.com/NuGet/Engineering/issues/1440