### PR TITLE
Adding the ability to specify MaxConcurrentCalls for the SubscriptionProcessor

### DIFF
--- a/src/NuGet.Services.Contracts/ServiceBus/IOnMessageOptions.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/IOnMessageOptions.cs
@@ -6,5 +6,6 @@ namespace NuGet.Services.ServiceBus
     public interface IOnMessageOptions
     {
         bool AutoComplete { get; set; }
+        int MaxConcurrentCalls { get; set; }
     }
 }

--- a/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/ISubscriptionProcessor.cs
@@ -20,7 +20,16 @@ namespace NuGet.Services.ServiceBus
         /// <summary>
         /// Start handling messages emitted to the Service Bus subscription.
         /// </summary>
+        /// <remarks>
+        /// MaxConcurrentMessages is defaulted to the number set by the ServiceBus library (seems to be 1)
+        /// </remarks>
         void Start();
+
+        /// <summary>
+        /// Start handling messages emitted to the Service Bus subscription.
+        /// </summary>
+        /// <param name="maxConcurrentCalls">Maximum number of messages processed in parallel.</param>
+        void Start(int maxConcurrentCalls);
 
         /// <summary>
         /// Deregisters the message handler and waits until currently in-flight messages have been handled.

--- a/src/NuGet.Services.ServiceBus/OnMessageOptionsWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/OnMessageOptionsWrapper.cs
@@ -16,6 +16,12 @@ namespace NuGet.Services.ServiceBus
             set => OnMessageOptions.AutoComplete = value;
         }
 
+        public int MaxConcurrentCalls
+        {
+            get => OnMessageOptions.MaxConcurrentCalls;
+            set => OnMessageOptions.MaxConcurrentCalls = value;
+        }
+
         public OnMessageOptionsWrapper(OnMessageOptions options = null)
         {
             OnMessageOptions = OnMessageOptions ?? new OnMessageOptions();

--- a/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
+++ b/src/NuGet.Services.ServiceBus/SubscriptionProcessor.cs
@@ -56,12 +56,29 @@ namespace NuGet.Services.ServiceBus
         {
             _logger.LogInformation("Registering the handler to begin listening to the Service Bus subscription");
 
-            _running = true;
-
-            _client.OnMessageAsync(OnMessageAsync, new OnMessageOptionsWrapper
+            StartInternal(new OnMessageOptionsWrapper
             {
                 AutoComplete = false,
             });
+        }
+
+        public void Start(int maxConcurrentCalls)
+        {
+            _logger.LogInformation("Registering the handler to begin listening to the Service Bus subscription with maxConcurrentCalls = {MaxConcurrentCalls}",
+                maxConcurrentCalls);
+
+            StartInternal(new OnMessageOptionsWrapper
+            {
+                AutoComplete = false,
+                MaxConcurrentCalls = maxConcurrentCalls
+            });
+        }
+
+        private void StartInternal(OnMessageOptionsWrapper onMessageOptions)
+        {
+            _running = true;
+
+            _client.OnMessageAsync(OnMessageAsync, onMessageOptions);
         }
 
         private async Task OnMessageAsync(IBrokeredMessage brokeredMessage)


### PR DESCRIPTION
Previously we used whatever default value ServiceBus library provided (which seem to be 1). Now, we'd be able to specify whatever we want.
Previous behavior is kept: `Start()` without arguments still uses the default library setting. New behavior is opt-in by means of `Start(int)` method.