### PR TITLE
Tool for running SQL AAD connection tests

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -70,6 +70,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Status.Table
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Incidents", "src\NuGet.Services.Incidents\NuGet.Services.Incidents.csproj", "{09B15FA8-8B24-4C9A-B2AC-1265ACCB9EB1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{2E74C554-630C-4ED9-BB66-81CFA5DFFBD3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureSqlConnectionTest", "tools\AzureSqlConnectionTest\AzureSqlConnectionTest.csproj", "{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -192,6 +196,10 @@ Global
 		{09B15FA8-8B24-4C9A-B2AC-1265ACCB9EB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09B15FA8-8B24-4C9A-B2AC-1265ACCB9EB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09B15FA8-8B24-4C9A-B2AC-1265ACCB9EB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -226,6 +234,7 @@ Global
 		{EA54BC71-F9AD-4863-8DC6-8CC41776C881} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{8D3E82F2-B637-4BA4-BD80-3380E826CA1A} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{09B15FA8-8B24-4C9A-B2AC-1265ACCB9EB1} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
+		{109E6F0E-CBBC-427A-89CF-8F8AACE479CF} = {2E74C554-630C-4ED9-BB66-81CFA5DFFBD3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AA413DB0-5475-4B5D-A3AF-6323DA8D538B}

--- a/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
@@ -33,6 +33,16 @@ namespace NuGet.Services.Sql
 
         #endregion
 
+        public AzureSqlConnectionFactory(
+            AzureSqlConnectionStringBuilder connectionString,
+            ISecretInjector secretInjector,
+            ILogger logger = null)
+        {
+            ConnectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            SecretInjector = secretInjector ?? throw new ArgumentNullException(nameof(secretInjector));
+            Logger = logger;
+        }
+
         public AzureSqlConnectionFactory(string connectionString, ISecretInjector secretInjector, ILogger logger = null)
         {
             if (string.IsNullOrEmpty(connectionString))

--- a/tools/AzureSqlConnectionTest/App.config
+++ b/tools/AzureSqlConnectionTest/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/tools/AzureSqlConnectionTest/AzureSqlConnectionTest.csproj
+++ b/tools/AzureSqlConnectionTest/AzureSqlConnectionTest.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{109E6F0E-CBBC-427A-89CF-8F8AACE479CF}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>AzureSqlConnectionTest</RootNamespace>
+    <AssemblyName>AzureSqlConnectionTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestApplication.cs" />
+    <Compile Include="TestRunner.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{c87d0ef1-54aa-4b0b-89de-cff2dc941d11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\NuGet.Services.Sql\NuGet.Services.Sql.csproj">
+      <Project>{f5121b0a-669f-48bd-86dc-27c546d1a825}</Project>
+      <Name>NuGet.Services.Sql</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils">
+      <Version>1.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/AzureSqlConnectionTest/AzureSqlConnectionTest.csproj
+++ b/tools/AzureSqlConnectionTest/AzureSqlConnectionTest.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AzureSqlConnectionTest</RootNamespace>
     <AssemblyName>AzureSqlConnectionTest</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/tools/AzureSqlConnectionTest/Program.cs
+++ b/tools/AzureSqlConnectionTest/Program.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace AzureSqlConnectionTest
 {
     class Program
@@ -10,8 +8,6 @@ namespace AzureSqlConnectionTest
         static void Main(string[] args)
         {
             new TestApplication().Execute(args);
-
-            Console.ReadKey();
         }
     }
 }

--- a/tools/AzureSqlConnectionTest/Program.cs
+++ b/tools/AzureSqlConnectionTest/Program.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace AzureSqlConnectionTest
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new TestApplication().Execute(args);
+
+            Console.ReadKey();
+        }
+    }
+}

--- a/tools/AzureSqlConnectionTest/Properties/AssemblyInfo.cs
+++ b/tools/AzureSqlConnectionTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AzureSqlConnectionTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AzureSqlConnectionTest")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("109e6f0e-cbbc-427a-89cf-8f8aace479cf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/AzureSqlConnectionTest/Properties/AssemblyInfo.cs
+++ b/tools/AzureSqlConnectionTest/Properties/AssemblyInfo.cs
@@ -1,36 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
+// General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("AzureSqlConnectionTest")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyDescription("Tool for testing AAD authenticated SQL connections using NuGet.Services.Sql")]
 [assembly: AssemblyProduct("AzureSqlConnectionTest")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2017")]
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("109e6f0e-cbbc-427a-89cf-8f8aace479cf")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/AzureSqlConnectionTest/TestApplication.cs
+++ b/tools/AzureSqlConnectionTest/TestApplication.cs
@@ -54,10 +54,10 @@ namespace AzureSqlConnectionTest
             SpawnClients = Option("-spawn", "Spawn client processes", CommandOptionType.NoValue);
             UseAdalOnly = Option("-adal", "Use ADAL only (default token cache)", CommandOptionType.NoValue);
 
-            OnExecute(() => OnTestExecute());
+            OnExecute(() => ExecuteAsync().GetAwaiter().GetResult());
         }
 
-        public int OnTestExecute()
+        public async Task<int> ExecuteAsync()
         {
             if (!Help.HasValue())
             {
@@ -67,12 +67,7 @@ namespace AzureSqlConnectionTest
 
                 if (count > 1 && SpawnClients.HasValue())
                 {
-                    return Task.Run(
-                        async () => await SpawnTestClients(
-                            count,
-                            durationInSeconds,
-                            intervalInSeconds)
-                        ).Result;
+                    return await SpawnTestClients(count, durationInSeconds, intervalInSeconds);
                 }
 
                 var persist = PersistConnections.HasValue();
@@ -93,14 +88,12 @@ namespace AzureSqlConnectionTest
                             ConnectionString.Value(),
                             keyVaultConfig);
 
-                        return Task.Run(
-                            async () => await runner.TestConnectionsAsync(
-                                count,
-                                durationInSeconds,
-                                intervalInSeconds,
-                                persist,
-                                useAdalOnly)
-                            ).Result;
+                        return await runner.TestConnectionsAsync(
+                            count,
+                            durationInSeconds,
+                            intervalInSeconds,
+                            persist,
+                            useAdalOnly);
                     }
                 }
             }
@@ -171,7 +164,7 @@ namespace AzureSqlConnectionTest
         private static X509Certificate2 GetKeyVaultCertificate(string kvCertThumbprint)
         {
             return CertificateUtility.FindCertificateByThumbprint(
-                StoreName.My, StoreLocation.LocalMachine, kvCertThumbprint, true);
+                StoreName.My, StoreLocation.LocalMachine, kvCertThumbprint, validationRequired: true);
         }
     }
 }

--- a/tools/AzureSqlConnectionTest/TestApplication.cs
+++ b/tools/AzureSqlConnectionTest/TestApplication.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Services.KeyVault;
+
+namespace AzureSqlConnectionTest
+{
+    public class TestApplication : CommandLineApplication
+    {
+        public CommandOption Help { get; }
+
+        public CommandOption KeyVaultName { get; }
+
+        public CommandOption KeyVaultClientId { get; }
+
+        public CommandOption KeyVaultCertificateThumbprint { get; }
+
+        public CommandOption ConnectionString { get; }
+
+        public CommandOption Count { get; }
+
+        public CommandOption PersistConnections { get; }
+
+        public CommandOption DurationInSeconds { get; }
+
+        public CommandOption IntervalInSeconds { get; }
+
+        public CommandOption SpawnClients { get; }
+
+        public CommandOption UseAdalOnly { get; }
+
+        public TestApplication()
+        {
+            Help = HelpOption("-? | -h | --help");
+
+            KeyVaultName = Option("-kv | --keyVaultName", "KeyVault name", CommandOptionType.SingleValue);
+            KeyVaultClientId = Option("-kvcid | --keyVaultClientId", "KeyVault client id", CommandOptionType.SingleValue);
+            KeyVaultCertificateThumbprint = Option("-kvct | --keyVaultCertThumbprint", "KeyVault certificate thumbprint", CommandOptionType.SingleValue);
+
+            ConnectionString = Option("-cs | --connectionString", "SQL connection string", CommandOptionType.SingleValue);
+
+            Count = Option("-c | --count", "Client count", CommandOptionType.SingleValue);
+            PersistConnections = Option("-p | --persist", "Persist connections", CommandOptionType.NoValue);
+            DurationInSeconds = Option("-d | --duration", "Duration in seconds", CommandOptionType.SingleValue);
+            IntervalInSeconds = Option("-i | --interval", "Sleep interval in seconds", CommandOptionType.SingleValue);
+
+            SpawnClients = Option("-spawn", "Spawn client processes", CommandOptionType.NoValue);
+            UseAdalOnly = Option("-adal", "Use ADAL only (default token cache)", CommandOptionType.NoValue);
+
+            OnExecute(() => OnTestExecute());
+        }
+
+        public int OnTestExecute()
+        {
+            if (!Help.HasValue())
+            {
+                var count = IntValue(Count, defaultValue: 1);
+                var durationInSeconds = IntValue(DurationInSeconds, defaultValue: 60);
+                var intervalInSeconds = IntValue(IntervalInSeconds, defaultValue: 15);
+
+                if (count > 1 && SpawnClients.HasValue())
+                {
+                    return Task.Run(
+                        async () => await SpawnTestClients(
+                            count,
+                            durationInSeconds,
+                            intervalInSeconds)
+                        ).Result;
+                }
+
+                var persist = PersistConnections.HasValue();
+                var useAdalOnly = UseAdalOnly.HasValue();
+
+                if (KeyVaultName.HasValue()
+                    && KeyVaultClientId.HasValue()
+                    && KeyVaultCertificateThumbprint.HasValue())
+                {
+                    using (var kvCertificate = GetKeyVaultCertificate(KeyVaultCertificateThumbprint.Value()))
+                    {
+                        var keyVaultConfig = new KeyVaultConfiguration(
+                            KeyVaultName.Value(),
+                            KeyVaultClientId.Value(),
+                            kvCertificate);
+
+                        var runner = new TestRunner(
+                            ConnectionString.Value(),
+                            keyVaultConfig);
+
+                        return Task.Run(
+                            async () => await runner.TestConnectionsAsync(
+                                count,
+                                durationInSeconds,
+                                intervalInSeconds,
+                                persist,
+                                useAdalOnly)
+                            ).Result;
+                    }
+                }
+            }
+
+            ShowHelp();
+
+            return 1;
+        }
+
+        private async Task<int> SpawnTestClients(int count, int durationInSeconds, int intervalInSeconds)
+        {
+            var clients = new Task<int>[count];
+            for (int i = 0; i < count; i++)
+            {
+                clients[i] = Task.Run(() => SpawnTestClient(durationInSeconds, intervalInSeconds));
+            }
+
+            await Task.WhenAll(clients);
+
+            return clients.Count(c => c.Result != 0);
+        }
+
+        private int SpawnTestClient(int durationInSeconds, int intervalInSeconds)
+        {
+            var commandLine = GetTestClientCommandLine();
+
+            var client = Process.Start(commandLine[0], commandLine[1]);
+            if (!client.WaitForExit((durationInSeconds + (intervalInSeconds * 2)) * 1000))
+            {
+                client.Kill();
+                return 1;
+            }
+
+            return client.ExitCode;
+        }
+
+        private static string[] GetTestClientCommandLine()
+        {
+            var commandLine = Environment.CommandLine;
+
+            commandLine = Regex.Replace(commandLine,
+                "-c(ount)? \\d+",
+                "",
+                RegexOptions.None,
+                TimeSpan.FromSeconds(5));
+
+            commandLine = Regex.Replace(commandLine,
+                "-spawn",
+                "",
+                RegexOptions.None,
+                TimeSpan.FromSeconds(5));
+
+            var parts = commandLine.Split(' ');
+            var arguments = parts
+                .Skip(1)
+                .Where(p => !String.IsNullOrEmpty(p));
+
+            return new[] { parts[0], String.Join(" ", arguments) };
+        }
+
+        private static int IntValue(CommandOption option, int defaultValue = -1)
+        {
+            return option.HasValue() && Int32.TryParse(option.Value(), out var result)
+                ? result
+                : defaultValue;
+        }
+
+        private static X509Certificate2 GetKeyVaultCertificate(string kvCertThumbprint)
+        {
+            return CertificateUtility.FindCertificateByThumbprint(
+                StoreName.My, StoreLocation.LocalMachine, kvCertThumbprint, true);
+        }
+    }
+}

--- a/tools/AzureSqlConnectionTest/TestRunner.cs
+++ b/tools/AzureSqlConnectionTest/TestRunner.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using NuGet.Services.KeyVault;
+using NuGet.Services.Sql;
+
+namespace AzureSqlConnectionTest
+{
+    public class TestRunner
+    {
+        private const string DatabaseResource = "https://database.windows.net/";
+
+        private AzureSqlConnectionStringBuilder ConnectionString { get; }
+
+        private KeyVaultConfiguration KeyVaultConfig { get; }
+
+        private ISecretInjector SecretInjector { get; }
+
+        public TestRunner(string connectionString, KeyVaultConfiguration keyVaultConfig)
+        {
+            KeyVaultConfig = keyVaultConfig ?? throw new ArgumentNullException(nameof(keyVaultConfig));
+
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentException("Value cannot be null or empty", nameof(connectionString));
+            }
+
+            ConnectionString = new AzureSqlConnectionStringBuilder(connectionString);
+            SecretInjector = new SecretInjector(new KeyVaultReader(KeyVaultConfig));
+        }
+
+        public async Task<int> TestConnectionsAsync(
+            int count,
+            int durationInSeconds,
+            int intervalInSeconds,
+            bool persist,
+            bool useAdalOnly)
+        {
+            Console.WriteLine($"Test started: {count} clients, {durationInSeconds}s duration, {intervalInSeconds}s interval, persist = {persist}, adal = {useAdalOnly}");
+
+            var testAsync = persist ? (Func<int, int, bool, Task<int>>)
+                TestPersistentConnectionAsync
+                : TestTransientConnectionAsync;
+
+            var clients = new Task<int>[count];
+            for (int i = 0; i < count; i++)
+            {
+                clients[i] = Task.Run(async () =>
+                {
+                    return await testAsync(durationInSeconds, intervalInSeconds, useAdalOnly);
+                });
+            }
+
+            await Task.WhenAll(clients);
+
+            var errorCount = clients.Sum(c => c.Result);
+
+            Console.WriteLine($"Test completed: {errorCount} error(s).");
+
+            return errorCount;
+        }
+
+        private async Task<int> TestTransientConnectionAsync(
+            int durationInSeconds,
+            int intervalInSeconds,
+            bool useAdalOnly)
+        {
+            return await TestConnectionInternalAsync(
+                durationInSeconds,
+                intervalInSeconds,
+                useAdalOnly,
+                CreateNewSqlConnectionAsync);
+        }
+
+        private async Task<int> TestPersistentConnectionAsync(
+            int durationInSeconds,
+            int intervalInSeconds,
+            bool useAdalOnly)
+        {
+            return await TestConnectionInternalAsync(
+                durationInSeconds,
+                intervalInSeconds,
+                useAdalOnly,
+                GetPersistentSqlConnectionAsync);
+        }
+
+        private async Task<int> TestConnectionInternalAsync(
+            int durationInSeconds,
+            int intervalInSeconds,
+            bool useAdalOnly,
+            Func<SqlConnection, bool, Task<SqlConnection>> createOrGetConnectionAsync)
+        {
+            var errorCount = 0;
+            SqlConnection lastConnection = null;
+
+            var instanceId = Guid.NewGuid();
+            var start = DateTimeOffset.Now;
+            do
+            {
+                try
+                {
+                    lastConnection = await createOrGetConnectionAsync(
+                        lastConnection,
+                        useAdalOnly);
+
+                    await ConnectionTestAsync(instanceId, lastConnection);
+                }
+                catch (Exception e)
+                {
+                    errorCount++;
+                    Console.WriteLine($"Failed [{instanceId}]: {e}");
+                }
+
+                await Task.Delay(intervalInSeconds * 1000);
+            }
+            while (KeepAlive(start, durationInSeconds));
+
+            if (lastConnection != null)
+            {
+                lastConnection.Dispose();
+            }
+
+            return errorCount;
+        }
+
+        private async Task ConnectionTestAsync(Guid instanceId, SqlConnection connection)
+        {
+            // AccessToken value is only available before the connection is opened.
+            var token = connection.AccessToken.GetHashCode();
+            if (connection.State != ConnectionState.Open)
+            {
+                await connection.OpenAsync();
+            }
+
+            var connectionId = connection.GetHashCode();
+            using (var cmd = new SqlCommand("SELECT CURRENT_USER", connection))
+            {
+                var result = await cmd.ExecuteScalarAsync();
+                Console.WriteLine($"Connected [{instanceId}]: {result} C:({connectionId}) T:({token})");
+            }
+        }
+
+        private bool KeepAlive(DateTimeOffset start, int durationInSeconds)
+        {
+            return (DateTimeOffset.Now - start).TotalSeconds < durationInSeconds;
+        }
+
+        private Task<SqlConnection> CreateNewSqlConnectionAsync(
+            SqlConnection lastConnection,
+            bool useAdalOnly)
+        {
+            if (lastConnection != null)
+            {
+                lastConnection.Dispose();
+            }
+
+            return useAdalOnly ? CreateAdalSqlConnection() : CreateNuGetSqlConnection();
+        }
+
+        private async Task<SqlConnection> GetPersistentSqlConnectionAsync(
+            SqlConnection lastConnection,
+            bool useAdalOnly)
+        {
+            return lastConnection ?? await CreateNewSqlConnectionAsync(null, useAdalOnly);
+        }
+
+        private Task<SqlConnection> CreateNuGetSqlConnection()
+        {
+            var connectionFactory = new AzureSqlConnectionFactory(ConnectionString, SecretInjector);
+            return connectionFactory.CreateAsync();
+        }
+
+        private async Task<SqlConnection> CreateAdalSqlConnection()
+        {
+            var certData = await SecretInjector.InjectAsync(ConnectionString.AadCertificate);
+            var certificate = new X509Certificate2(Convert.FromBase64String(certData), string.Empty);
+
+            var clientAssertionCert = new ClientAssertionCertificate(ConnectionString.AadClientId, certificate);
+            var authContext = new AuthenticationContext(ConnectionString.AadAuthority, tokenCache: null);
+            var token = await authContext.AcquireTokenAsync(DatabaseResource, clientAssertionCert, ConnectionString.AadSendX5c);
+
+            var connection = new SqlConnection(ConnectionString.ConnectionString);
+            connection.AccessToken = token.AccessToken;
+
+            return connection;
+        }
+    }
+}

--- a/tools/AzureSqlConnectionTest/TestRunner.cs
+++ b/tools/AzureSqlConnectionTest/TestRunner.cs
@@ -133,7 +133,7 @@ namespace AzureSqlConnectionTest
         private async Task ConnectionTestAsync(Guid instanceId, SqlConnection connection)
         {
             // AccessToken value is only available before the connection is opened.
-            var token = connection.AccessToken.GetHashCode();
+            var token = connection.AccessToken?.GetHashCode();
             if (connection.State != ConnectionState.Open)
             {
                 await connection.OpenAsync();
@@ -143,7 +143,8 @@ namespace AzureSqlConnectionTest
             using (var cmd = new SqlCommand("SELECT CURRENT_USER", connection))
             {
                 var result = await cmd.ExecuteScalarAsync();
-                Console.WriteLine($"Connected [{instanceId}]: {result} C:({connectionId}) T:({token})");
+                var tokenStr = token?.ToString() ?? "persisted";
+                Console.WriteLine($"Connected [{instanceId}]: {result} C:({connectionId}) T:({tokenStr})");
             }
         }
 

--- a/tools/AzureSqlConnectionTest/TestRunner.cs
+++ b/tools/AzureSqlConnectionTest/TestRunner.cs
@@ -43,7 +43,7 @@ namespace AzureSqlConnectionTest
             bool persist,
             bool useAdalOnly)
         {
-            Console.WriteLine($"Test started: {count} clients, {durationInSeconds}s duration, {intervalInSeconds}s interval, persist = {persist}, adal = {useAdalOnly}");
+            LogMessage($"Test started: {count} clients, {durationInSeconds}s duration, {intervalInSeconds}s interval, persist = {persist}, adal = {useAdalOnly}{Environment.NewLine}");
 
             var testAsync = persist ? (Func<int, int, bool, Task<int>>)
                 TestPersistentConnectionAsync
@@ -62,7 +62,8 @@ namespace AzureSqlConnectionTest
 
             var errorCount = clients.Sum(c => c.Result);
 
-            Console.WriteLine($"Test completed: {errorCount} error(s).");
+            LogMessage($"{Environment.NewLine}Test completed: {errorCount} error(s). Press any key to exit.");
+            Console.ReadKey();
 
             return errorCount;
         }
@@ -115,7 +116,7 @@ namespace AzureSqlConnectionTest
                 catch (Exception e)
                 {
                     errorCount++;
-                    Console.WriteLine($"Failed [{instanceId}]: {e}");
+                    LogMessage($"Failed [{instanceId}]: {e}");
                 }
 
                 await Task.Delay(intervalInSeconds * 1000);
@@ -144,7 +145,7 @@ namespace AzureSqlConnectionTest
             {
                 var result = await cmd.ExecuteScalarAsync();
                 var tokenStr = token?.ToString() ?? "persisted";
-                Console.WriteLine($"Connected [{instanceId}]: {result} C:({connectionId}) T:({tokenStr})");
+                LogMessage($"Connected [{instanceId}]: {result} C:({connectionId}) T:({tokenStr})");
             }
         }
 
@@ -191,6 +192,12 @@ namespace AzureSqlConnectionTest
             connection.AccessToken = token.AccessToken;
 
             return connection;
+        }
+
+        private void LogMessage(string s)
+        {
+            var timestamp = DateTime.Now.ToString("s");
+            Console.WriteLine($"[{timestamp}] {s}");
         }
     }
 }


### PR DESCRIPTION
Allows for testing:
- Concurrent connections using the same AAD credentials, same access tokens
- Concurrent connections in-proc or out-of-proc
- Short- or long-lived connections
- Long-lived connections that are idle
- Using latest `NuGet.Services.Sql` or default ADAL

Based on initial tests, doesn't seem like there's a limit on # connections per certificate or access token... though I need to test with longer runs. I haven't been able to repro the original "Login failed for user" exceptions yet, which seemed to happen after deploying N jobs.

I have seen the following exception if I add a breakpoint after initial connection open, but retry succeeds. Will investigate this.
```
Test started: 10 clients, 60s duration, 15s interval, persist = False, adal = False
Failed [acb21c92-76ef-4526-9b95-63e0c8dcd9f0]: System.Data.SqlClient.SqlException (0x80131904): The client was unable to establish a connection because of an error during connection initialization process before login. Possible causes include the following:  the client tried to connect to an unsupported version of SQL Server; the server was too busy to accept new connections; or there was a resource limitation (insufficient memory or maximum allowed connections) on the server. (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by the remote host.) ---> System.ComponentModel.Win32Exception (0x80004005): An existing connection was forcibly closed by the remote host
   at System.Data.SqlClient.SqlInternalConnectionTds..ctor(DbConnectionPoolIdentity identity, SqlConnectionString connectionOptions, SqlCredential credential, Object providerInfo, String newPassword, SecureString newSecurePassword, Boolean redirectedUserInstance, SqlConnectionString userConnectionOptions, SessionData reconnectSessionData, DbConnectionPool pool, String accessToken, Boolean applyTransientFaultHandling, SqlAuthenticationProviderManager sqlAuthProviderManager)
   at System.Data.SqlClient.SqlConnectionFactory.CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, Object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
   at System.Data.ProviderBase.DbConnectionFactory.CreatePooledConnection(DbConnectionPool pool, DbConnection owningObject, DbConnectionOptions options, DbConnectionPoolKey poolKey, DbConnectionOptions userOptions)
   at System.Data.ProviderBase.DbConnectionPool.CreateObject(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)
   at System.Data.ProviderBase.DbConnectionPool.UserCreateRequest(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)
   at System.Data.ProviderBase.DbConnectionPool.TryGetConnection(DbConnection owningObject, UInt32 waitForMultipleObjectsTimeout, Boolean allowCreate, Boolean onlyOneCheckConnection, DbConnectionOptions userOptions, DbConnectionInternal& connection)
   at System.Data.ProviderBase.DbConnectionPool.WaitForPendingOpen()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at AzureSqlConnectionTest.TestRunner.<ConnectionTestAsync>d__15.MoveNext() in D:\Nuget\ServerCommon\tools\AzureSqlConnectionTest\TestRunner.cs:line 137
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at AzureSqlConnectionTest.TestRunner.<TestConnectionInternalAsync>d__14.MoveNext() in D:\Nuget\ServerCommon\tools\AzureSqlConnectionTest\TestRunner.cs:line 113
ClientConnectionId:bbbed2d4-35dc-44e8-b7e1-6240cf6490cc
Error Number:10054,State:0,Class:20
```

Next steps:
- Longer test runs
- Resubmit PR for NuGet.Services.Sql TokenCache fixes (non-functional w/o config change this time)
- Start moving jobs off Octopus config; would prefer to do before changing SQL AAD config this time, to avoid pain of reverting in case more stabilization is necessary.