### PR TITLE
Fix $FilePath bug with init.ps1

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -26,7 +26,7 @@ Function Get-BuildTools {
             [string]$Path
         )
         
-        $DirectoryPath = (Join-Path $NuGetClientRoot $FilePath)
+        $DirectoryPath = (Join-Path $NuGetClientRoot $Path)
         if (-not (Test-Path $DirectoryPath)) {
             New-Item -Path $DirectoryPath -ItemType "directory"
         }


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6334

We have a minor "null reference" bug with `init.ps1`, but we haven't noticed it yet because our build machines have strict mode off and the script works anyway due to some coincidences with how PowerShell works.