### PR TITLE
Build function to pack PackageReference projects with dependencies

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -569,6 +569,72 @@ Function New-Package {
     }
 }
 
+Function New-ProjectPackage {
+    [CmdletBinding()]
+    param(
+        [Alias('target')]
+        [string]$TargetFilePath,
+        [string]$TargetProfile,
+        [string]$Configuration,
+        [string]$ReleaseLabel,
+        [string]$BuildNumber,
+        [switch]$NoPackageAnalysis,
+        [string]$PackageId,
+        [string]$Version,
+        [string]$MSBuildVersion = $DefaultMSBuildVersion,
+        [switch]$Symbols,
+        [string]$Branch,
+        [switch]$IncludeReferencedProjects
+    )
+    Trace-Log "Creating package from @""$TargetFilePath"""
+    
+    $MSBuildExe = Get-MSBuildExe $MSBuildVersion
+    
+    $opts = , $TargetFilePath
+    $opts += "/t:pack"
+    
+    $opts += "/p:Configuration=$Configuration;BuildNumber=$(Format-BuildNumber $BuildNumber)"
+    $opts += "/p:PackageOutputPath=$Artifacts"
+    
+    if ($Version){
+        $PackageVersion = $Version
+    }
+    elseif ($ReleaseLabel) {
+        $PackageVersion = Get-PackageVersion $ReleaseLabel $BuildNumber
+    }
+    
+    if ($PackageVersion) {
+        $opts += "/p:PackageVersion=$PackageVersion"
+    }
+    
+    if ($TargetProfile) {
+        $opts += "/p:TargetProfile=$TargetProfile"
+    }
+    
+    if ($NoPackageAnalysis) {
+        $opts += '/p:NoPackageAnalysis=True'
+    }
+    
+    if ($Symbols) {
+        $opts += "/p:IncludeSymbols=True"
+    }
+    
+    if (-not (Test-Path $Artifacts)) {
+        New-Item $Artifacts -Type Directory
+    }
+    
+    $OutputDir = Join-Path $Artifacts $TargetProfile
+    if (-not (Test-Path $OutputDir)) {
+        New-Item $OutputDir -Type Directory
+    }
+    
+    Trace-Log "$MsBuildExe $opts"
+    & $MsBuildExe $opts
+    if (-not $?) {
+        Error-Log "Pack failed for @""$TargetFilePath"". Code: ${LASTEXITCODE}"
+    }
+}
+
 Function Set-AppSetting($webConfig, [string]$name, [string]$value) {
     $setting = $webConfig.configuration.appSettings.add | where { $_.key -eq $name }
     if($setting) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -596,6 +596,10 @@ Function New-ProjectPackage {
     $opts += "/p:Configuration=$Configuration;BuildNumber=$(Format-BuildNumber $BuildNumber)"
     $opts += "/p:PackageOutputPath=$Artifacts"
     
+    if ($PackageId) {
+        $opts += "/p:PackageId=$PackageId"
+    }
+    
     if ($Version){
         $PackageVersion = $Version
     }


### PR DESCRIPTION
Add `New-Package` replacement that includes dependencies when building projects that use PackageReferences. This is based on the workaround from @rohit21agrawal in https://github.com/NuGet/Home/issues/5979

Requirement for https://github.com/NuGet/NuGetGallery/issues/6348