### PR TITLE
Add default and custom FxCop support

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -277,12 +277,13 @@ Function Invoke-FxCop {
                 throw "Failed to find $FxCopRuleSet under $FxCopDirectory"
             }
         }
+    }
+    
+    # Write FxCop logs to specific output directory
+    if ($FxCopOutputDirectory) {
+        $env:FXCOP_OUTPUT_DIRECTORY = $FxCopOutputDirectory
         
-        if ($FxCopOutputDirectory) {
-            $env:FXCOP_OUTPUT_DIRECTORY = $FxCopOutputDirectory
-            
-            Trace-Log "Using FXCOP_OUTPUT_DIRECTORY=$FxCopOutputDirectory"
-        }
+        Trace-Log "Using FXCOP_OUTPUT_DIRECTORY=$FxCopOutputDirectory"
     }
     
     # Invoke using the msbuild RunCodeAnalysis target

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -222,6 +222,79 @@ Function Build-Solution {
     }
 }
 
+Function Invoke-FxCop {
+    [CmdletBinding()]
+    param(
+        [string]$Configuration = $DefaultConfiguration,
+        [int]$BuildNumber = (Get-BuildNumber),
+        [string]$MSBuildVersion = $DefaultMSBuildVersion,
+        [string]$SolutionPath,
+        [switch]$SkipRestore,
+        [string]$FxCopDirectory,
+        [string]$FxCopProject,
+        [string]$FxCopRuleSet,
+        [string]$FxCopOutputDirectory
+    )
+    
+    # Ensure cleanup from previous runs
+    Get-ChildItem -Recurse "*.CodeAnalysisLog.xml" | Remove-Item
+    
+    $env:FXCOP_DIRECTORY = ''
+    $env:FXCOP_PROJECT = ''
+    $env:FXCOP_RULESET = ''
+    $env:FXCOP_RULESET_DIRECTORY = ''
+    $env:FXCOP_OUTPUT_DIRECTORY = ''
+    
+    # Configure FxCop defaults
+    $codeAnalysisProps = Resolve-Path $(Join-Path 'build' 'nuget.codeanalysis.props')
+    
+    # Configure FxCop overrides
+    if ($FxCopDirectory) {
+        $env:FXCOP_DIRECTORY = $FxCopDirectory
+        Trace-Log "Using FXCOP_DIRECTORY=$env:FXCOP_DIRECTORY"
+                
+        if ($FxCopProject) {
+            $items = Get-ChildItem $(Join-Path $FxCopDirectory $FxCopProject) -Recurse
+            
+            if ($items.Count -gt 0) {
+                $env:FXCOP_PROJECT = $items[0]                
+                Trace-Log "Discovered FXCOP_PROJECT=$env:FXCOP_PROJECT"
+            }
+            else {
+                throw "Failed to find $FxCopProject under $FxCopDirectory"
+            }
+        }
+        
+        if ($FxCopRuleSet) {
+            $items = Get-ChildItem $(Join-Path $FxCopDirectory $FxCopRuleSet) -Recurse
+            
+            if ($items.Count -gt 0) {
+                $env:FXCOP_RULESET = $items[0]
+                $env:FXCOP_RULESET_DIRECTORY = $($items[0]).Directory
+                Trace-Log "Discovered FXCOP_RULESET=$FxCopRuleSetFullPath"
+            }
+            else {
+                throw "Failed to find $FxCopRuleSet under $FxCopDirectory"
+            }
+        }
+        
+        if ($FxCopOutputDirectory) {
+            $env:FXCOP_OUTPUT_DIRECTORY = $FxCopOutputDirectory
+            
+            Trace-Log "Using FXCOP_OUTPUT_DIRECTORY=$FxCopOutputDirectory"
+        }
+    }
+    
+    # Invoke using the msbuild RunCodeAnalysis target
+    $msBuildProps = "/p:CustomBeforeMicrosoftCSharpTargets=$codeAnalysisProps"
+    
+    if ($VerbosePreference) {
+        $msBuildProps += ";CodeAnalysisVerbose=true"
+    }
+    
+    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $SolutionPath -Target "RunCodeAnalysis" -MSBuildProperties $msBuildProps -SkipRestore:$SkipRestore
+}
+
 Function Invoke-Git {
     [CmdletBinding()]
     Param(

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -292,7 +292,7 @@ Function Invoke-FxCop {
         $msBuildProps += ";CodeAnalysisVerbose=true"
     }
     
-    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $SolutionPath -Target "RunCodeAnalysis" -MSBuildProperties $msBuildProps -SkipRestore:$SkipRestore
+    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $SolutionPath -Target "Build;RunCodeAnalysis" -MSBuildProperties $msBuildProps -SkipRestore:$SkipRestore
 }
 
 Function Invoke-Git {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -280,8 +280,8 @@ Function Invoke-FxCop {
     }
     
     # Write FxCop logs to specific output directory
-    if ($FxCopOutputDirectory) {
-        $env:FXCOP_OUTPUT_DIRECTORY = $FxCopOutputDirectory
+    if (Test-Path $FxCopOutputDirectory) {
+        $env:FXCOP_OUTPUT_DIRECTORY = Resolve-Path $FxCopOutputDirectory
         
         Trace-Log "Using FXCOP_OUTPUT_DIRECTORY=$FxCopOutputDirectory"
     }

--- a/build/nuget.codeanalysis.props
+++ b/build/nuget.codeanalysis.props
@@ -16,7 +16,7 @@
     <!-- Default includes 'Excluded' (suppressions) -->
     <CodeAnalysisSaveMessagesToReport>Active</CodeAnalysisSaveMessagesToReport>
     
-    <CodeAnalysisLogFile Condition="'$(FXCOP_OUTPUT_DIRECTORY)' != ''">$(FXCOP_OUTPUT_DIRECTORY)/$(TargetFileName).CodeAnalysisLog.xml</CodeAnalysisLogFile>
+    <CodeAnalysisLogFile Condition="'$(FXCOP_OUTPUT_DIRECTORY)' != ''">$(FXCOP_OUTPUT_DIRECTORY)/$(AssemblyName).CodeAnalysisLog.xml</CodeAnalysisLogFile>
   </PropertyGroup>
   
   <!-- Custom FxCop execution for build agents -->

--- a/build/nuget.codeanalysis.props
+++ b/build/nuget.codeanalysis.props
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    
+    <CodeAnalysisSearchGlobalAssemblyCache>true</CodeAnalysisSearchGlobalAssemblyCache>
+    <CodeAnalysisIgnoreInvalidTargets>true</CodeAnalysisIgnoreInvalidTargets>
+    <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
+    <CodeAnalysisIgnoreMissingIndirectReferences>true</CodeAnalysisIgnoreMissingIndirectReferences>
+    <CodeAnalysisOutputToConsole>true</CodeAnalysisOutputToConsole>
+    <CodeAnalysisVerbose>false</CodeAnalysisVerbose>
+    <CodeAnalysisSummary>true</CodeAnalysisSummary>
+    
+    <!-- Default includes 'Excluded' (suppressions) -->
+    <CodeAnalysisSaveMessagesToReport>Active</CodeAnalysisSaveMessagesToReport>
+  </PropertyGroup>
+  
+  <!-- Custom FxCop execution for build agents -->
+  <PropertyGroup Condition="'$(FXCOP_DIRECTORY)' != ''">
+    <!-- If you see the following error, ensure that FxCop is installed on the same drive as source repositories. -->
+    <!-- "If using a shared project, all files must be on the same drive so that they can be referenced by relative paths. -->
+    <!--  MSBUILD : error : CA0501 : Unable to read output report" -->
+    <FxCopDir>$(FXCOP_DIRECTORY)</FxCopDir>
+    
+    <CodeAnalysisRuleDirectories>$(FxCopDir)/Rules</CodeAnalysisRuleDirectories>
+    <CodeAnalysisRuleSetDirectories Condition="'$(FXCOP_RULESET_DIRECTORY)' != ''">$(FXCOP_RULESET_DIRECTORY)</CodeAnalysisRuleSetDirectories>
+    
+    <CodeAnalysisProject Condition="'$(FXCOP_PROJECT)' != ''">$(FXCOP_PROJECT)</CodeAnalysisProject>
+    <CodeAnalysisRuleSet Condition="'$(FXCOP_RULESET)' != ''">$(FXCOP_RULESET)</CodeAnalysisRuleSet>
+    
+    <CodeAnalysisLogFile Condition="'$(FXCOP_OUTPUT_DIRECTORY)' != ''">$(FXCOP_OUTPUT_DIRECTORY)/$(TargetFileName).CodeAnalysisLog.xml</CodeAnalysisLogFile>
+  </PropertyGroup>
+  
+</Project>

--- a/build/nuget.codeanalysis.props
+++ b/build/nuget.codeanalysis.props
@@ -15,6 +15,8 @@
     
     <!-- Default includes 'Excluded' (suppressions) -->
     <CodeAnalysisSaveMessagesToReport>Active</CodeAnalysisSaveMessagesToReport>
+    
+    <CodeAnalysisLogFile Condition="'$(FXCOP_OUTPUT_DIRECTORY)' != ''">$(FXCOP_OUTPUT_DIRECTORY)/$(TargetFileName).CodeAnalysisLog.xml</CodeAnalysisLogFile>
   </PropertyGroup>
   
   <!-- Custom FxCop execution for build agents -->
@@ -29,8 +31,6 @@
     
     <CodeAnalysisProject Condition="'$(FXCOP_PROJECT)' != ''">$(FXCOP_PROJECT)</CodeAnalysisProject>
     <CodeAnalysisRuleSet Condition="'$(FXCOP_RULESET)' != ''">$(FXCOP_RULESET)</CodeAnalysisRuleSet>
-    
-    <CodeAnalysisLogFile Condition="'$(FXCOP_OUTPUT_DIRECTORY)' != ''">$(FXCOP_OUTPUT_DIRECTORY)/$(TargetFileName).CodeAnalysisLog.xml</CodeAnalysisLogFile>
   </PropertyGroup>
   
 </Project>

--- a/build/runcodeanalysis.ps1
+++ b/build/runcodeanalysis.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding(DefaultParameterSetName='RegularBuild')]
+param (
+    [ValidateSet("debug", "release")]
+    [string]$Configuration = 'debug',
+    [int]$BuildNumber,
+    [switch]$SkipRestore,
+    [string]$FxCopDirectory,
+    [string]$FxCopProject,
+    [string]$FxCopRuleSet,
+    [string]$FxCopOutputDirectory
+)
+
+# To avoid repository dependencies, this script relies on the following assumptions:
+# - parent directory contains a single *.sln
+# - parent directory contains a build.ps1
+# - build.ps1 has standard NuGet build arguments
+# - build.ps1 was already executed and sources were already fetched
+
+# Discover the solution
+$SolutionPath = $(Get-ChildItem -Path "$PSScriptRoot/../*.sln")[0]
+
+if (-not (Test-Path $SolutionPath)) {
+    throw "Solution $SolutionPath does not exist!"
+}
+
+# Discover the build branch from the solution's build script
+$buildScript = "$PSScriptRoot/../build.ps1"
+$buildBranchRegex = "(BuildBranch\s?=\s?[''""]?)(([^''""]*)+)[''""]?$"
+$buildBranchFound = gc $buildScript | where { $_ -match $buildBranchRegex }
+if ($buildBranchFound) {
+    $buildBranch = $Matches[2]
+    
+    if (! $buildBranch) {
+        throw "Could not determine the $BuildBranch from $buildBranch"
+    }
+}
+
+# Sync to the solution's build tools version
+. "$PSScriptRoot/init.ps1" -BuildBranch "$buildBranch"
+
+Write-Host ("`r`n" * 3)
+Trace-Log ('=' * 60)
+
+$startTime = [DateTime]::UtcNow
+if (-not $BuildNumber) {
+    $BuildNumber = Get-BuildNumber
+}
+Trace-Log "RunCodeAnalysis Build #$BuildNumber started at $startTime"
+
+$BuildErrors = @()
+    
+Invoke-BuildStep 'Running code analysis' { 
+        Invoke-FxCop $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore -FxCopDirectory $FxCopDirectory -FxCopProject $FxCopProject -FxCopRuleSet $FxCopRuleSet -FxCopOutputDirectory $FxCopOutputDirectory `
+    } `
+    -ev +BuildErrors
+
+Trace-Log ('-' * 60)
+
+## Calculating Build time
+$endTime = [DateTime]::UtcNow
+Trace-Log "RunCodeAnalysis Build #$BuildNumber ended at $endTime"
+Trace-Log "Time elapsed $(Format-ElapsedTime ($endTime - $startTime))"
+
+Trace-Log ('=' * 60)
+
+if ($BuildErrors) {
+    $ErrorLines = $BuildErrors | %{ ">>> $($_.Exception.Message)" }
+    Error-Log "Builds completed with $($BuildErrors.Count) error(s):`r`n$($ErrorLines -join "`r`n")" -Fatal
+}
+
+Write-Host ("`r`n" * 3)

--- a/build/runcodeanalysis.ps1
+++ b/build/runcodeanalysis.ps1
@@ -29,7 +29,10 @@ if (-not (Test-Path $SolutionPath)) {
 # Discover the build branch from the solution's build script
 $buildScript = "$PSScriptRoot/../build.ps1"
 $buildBranchRegex = "(BuildBranch\s?=\s?[''""]?)(([^''""]*)+)[''""]?$"
-$buildBranchFound = gc $buildScript | where { $_ -match $buildBranchRegex }
+# Powershell hang seen on non-matching expression, so we should always run with timeout.
+$regexTimeout = New-TimeSpan -Seconds 60
+$regex = New-Object -TypeName regex -ArgumentList '$buildBranchRegex', ([System.Text.RegularExpressions.RegexOptions]::None), $regexTimeout
+$buildBranchFound = gc $buildScript | where { $_ -match $regex }
 if ($buildBranchFound) {
     $buildBranch = $Matches[2]
     

--- a/build/runcodeanalysis.ps1
+++ b/build/runcodeanalysis.ps1
@@ -10,6 +10,9 @@ param (
     [string]$FxCopOutputDirectory
 )
 
+# Enable TLS 1.2 since GitHub requires it.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 # To avoid repository dependencies, this script relies on the following assumptions:
 # - parent directory contains a single *.sln
 # - parent directory contains a build.ps1

--- a/build/runcodeanalysis.ps1
+++ b/build/runcodeanalysis.ps1
@@ -10,25 +10,6 @@ param (
     [string]$FxCopOutputDirectory
 )
 
-Function Get-BuildBranch() {
-    $buildScriptPath = "$PSScriptRoot/../build.ps1"
-    if (-not $(Test-Path $buildScriptPath)) {
-        throw "Could not find build script '$buildScriptPath'."
-    }
-    $buildContent = Get-Content $buildScriptPath
-    
-    $regexOpts = ([System.Text.RegularExpressions.RegexOptions]::None)
-    $regexTimeout = New-TimeSpan -Seconds 60
-    $buildBranchRegex = "BuildBranch\s*=\s*[''""]?([^''""]+)[''""]?"
-    
-    $result = [regex]::Match($buildContent, $buildBranchRegex, $regexOptions, $regexTimeout)
-    if (-not ($result -and ($result.Groups.Count -gt 1))) {
-        throw "Could not determine build branch from $buildScriptPath."
-    }
-    
-    $result.Groups[1].Value
-}
-
 # Enable TLS 1.2 since GitHub requires it.
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
@@ -45,11 +26,8 @@ if (-not (Test-Path $SolutionPath)) {
     throw "Solution $SolutionPath does not exist!"
 }
 
-# Discover the build branch from the solution's build script
-$buildBranch = Get-BuildBranch
-
 # Sync to the solution's build tools version
-. "$PSScriptRoot/init.ps1" -BuildBranch "$buildBranch"
+. "$PSScriptRoot/common.ps1"
 
 Write-Host ("`r`n" * 3)
 Trace-Log ('=' * 60)


### PR DESCRIPTION
Tracking: https://github.com/NuGet/Engineering/issues/822

Issues with our current way of running FxCop (VSTS build task):
- Single invocation for all solution assemblies, which can result in runtime dependency conflicts
- Does not set CODE_ANALYSIS flag, so code suppressions would not be preserved
- Target discovery assumes project and assembly names match
- Hard to debug on dev machines

Proposal here is to use the `RunCodeAnalysis` msbuild task to invoke FxCop. By default, it uses the instance installed with VS and the minimum ruleset. This also supports custom FxCop installation, project and ruleset - which will be used by our build agents.

Currently, I've only tested against `NuGet.Services.Metadata` but will be testing other repos before I merge.