### PR TITLE
Add entity key to PackageValidationMessageData

### DIFF
--- a/src/NuGet.Services.Validation/PackageValidationMessageData.cs
+++ b/src/NuGet.Services.Validation/PackageValidationMessageData.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.Validation
            string packageId,
            string packageVersion,
            Guid validationTrackingId)
-         : this(packageId, packageVersion, validationTrackingId, validatingType: ValidatingType.Package, deliveryCount: 0, packageKey: null)
+         : this(packageId, packageVersion, validationTrackingId, validatingType: ValidatingType.Package, deliveryCount: 0, entityKey: null)
         {
         }
 
@@ -21,8 +21,8 @@ namespace NuGet.Services.Validation
             string packageVersion,
             Guid validationTrackingId,
             ValidatingType validatingType,
-            int? packageKey = null)
-          : this(packageId, packageVersion, validationTrackingId, validatingType, deliveryCount: 0, packageKey: packageKey)
+            int? entityKey = null)
+          : this(packageId, packageVersion, validationTrackingId, validatingType, deliveryCount: 0, entityKey: entityKey)
         {
         }
 
@@ -32,7 +32,7 @@ namespace NuGet.Services.Validation
             Guid validationTrackingId,
             ValidatingType validatingType,
             int deliveryCount,
-            int? packageKey = null)
+            int? entityKey = null)
         {
             if (validationTrackingId == Guid.Empty)
             {
@@ -45,7 +45,7 @@ namespace NuGet.Services.Validation
             ValidationTrackingId = validationTrackingId;
             DeliveryCount = deliveryCount;
             ValidatingType = validatingType;
-            PackageKey = packageKey;
+            EntityKey = entityKey;
         }
 
         public string PackageId { get; }
@@ -54,6 +54,6 @@ namespace NuGet.Services.Validation
         public Guid ValidationTrackingId { get; }
         public int DeliveryCount { get; }
         public ValidatingType ValidatingType { get; }
-        public int? PackageKey { get; }
+        public int? EntityKey { get; }
     }
 }

--- a/src/NuGet.Services.Validation/PackageValidationMessageData.cs
+++ b/src/NuGet.Services.Validation/PackageValidationMessageData.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.Validation
            string packageId,
            string packageVersion,
            Guid validationTrackingId)
-         : this(packageId, packageVersion, validationTrackingId, validatingType: ValidatingType.Package, deliveryCount: 0)
+         : this(packageId, packageVersion, validationTrackingId, validatingType: ValidatingType.Package, deliveryCount: 0, packageKey: null)
         {
         }
 
@@ -20,8 +20,9 @@ namespace NuGet.Services.Validation
             string packageId,
             string packageVersion,
             Guid validationTrackingId,
-            ValidatingType validatingType)
-          : this(packageId, packageVersion, validationTrackingId, validatingType, deliveryCount: 0)
+            ValidatingType validatingType,
+            int? packageKey = null)
+          : this(packageId, packageVersion, validationTrackingId, validatingType, deliveryCount: 0, packageKey: packageKey)
         {
         }
 
@@ -30,7 +31,8 @@ namespace NuGet.Services.Validation
             string packageVersion,
             Guid validationTrackingId,
             ValidatingType validatingType,
-            int deliveryCount)
+            int deliveryCount,
+            int? packageKey = null)
         {
             if (validationTrackingId == Guid.Empty)
             {
@@ -43,6 +45,7 @@ namespace NuGet.Services.Validation
             ValidationTrackingId = validationTrackingId;
             DeliveryCount = deliveryCount;
             ValidatingType = validatingType;
+            PackageKey = packageKey;
         }
 
         public string PackageId { get; }
@@ -51,5 +54,6 @@ namespace NuGet.Services.Validation
         public Guid ValidationTrackingId { get; }
         public int DeliveryCount { get; }
         public ValidatingType ValidatingType { get; }
+        public int? PackageKey { get; }
     }
 }

--- a/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
+++ b/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.Validation
                 PackageNormalizedVersion = message.PackageNormalizedVersion,
                 ValidationTrackingId = message.ValidationTrackingId,
                 ValidatingType = message.ValidatingType,
-                PackageKey = message.PackageKey
+                EntityKey = message.EntityKey
             });
         }
 
@@ -35,7 +35,7 @@ namespace NuGet.Services.Validation
                 data.ValidationTrackingId,
                 data.ValidatingType,
                 message.DeliveryCount,
-                data.PackageKey);
+                data.EntityKey);
         }
 
         [Schema(Name = PackageValidationSchemaName, Version = 1)]
@@ -46,7 +46,7 @@ namespace NuGet.Services.Validation
             public string PackageNormalizedVersion { get; set; }
             public Guid ValidationTrackingId { get; set; }
             public ValidatingType ValidatingType { get; set; }
-            public int? PackageKey { get; set; }
+            public int? EntityKey { get; set; }
         }
     }
 }

--- a/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
+++ b/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
@@ -20,7 +20,8 @@ namespace NuGet.Services.Validation
                 PackageVersion = message.PackageVersion,
                 PackageNormalizedVersion = message.PackageNormalizedVersion,
                 ValidationTrackingId = message.ValidationTrackingId,
-                ValidatingType = message.ValidatingType
+                ValidatingType = message.ValidatingType,
+                PackageKey = message.PackageKey
             });
         }
 
@@ -33,7 +34,8 @@ namespace NuGet.Services.Validation
                 data.PackageVersion,
                 data.ValidationTrackingId,
                 data.ValidatingType,
-                message.DeliveryCount);
+                message.DeliveryCount,
+                data.PackageKey);
         }
 
         [Schema(Name = PackageValidationSchemaName, Version = 1)]
@@ -44,6 +46,7 @@ namespace NuGet.Services.Validation
             public string PackageNormalizedVersion { get; set; }
             public Guid ValidationTrackingId { get; set; }
             public ValidatingType ValidatingType { get; set; }
+            public int? PackageKey { get; set; }
         }
     }
 }

--- a/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
@@ -68,13 +68,13 @@ namespace NuGet.Services.Validation.Tests
             public static IEnumerable<object[]> SerializedTestMessageData2 = new[]
             {
                 new object[] { TestData.SerializedPackageValidationMessageData2, PackageKey },
-                new object[] { TestData.SerializedPackageValidationMessageDataWithNoPackageKey2, null}
+                new object[] { TestData.SerializedPackageValidationMessageDataWithNoEntityKey2, null}
             };
 
             public static IEnumerable<object[]> SerializedTestMessageDataForSymbols = new[]
             {
                 new object[] { TestData.SerializedPackageValidationMessageDataSymbols, PackageKey },
-                new object[] { TestData.SerializedPackageValidationMessageDataSymbolsWithNoPackageKey, null}
+                new object[] { TestData.SerializedPackageValidationMessageDataSymbolsWithNoEntityKey, null}
             };
 
             [Theory]

--- a/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
@@ -94,7 +94,7 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.Package, output.ValidatingType);
-                Assert.Equal(expectedKey, output.PackageKey);
+                Assert.Equal(expectedKey, output.EntityKey);
             }
 
             [Fact]
@@ -113,7 +113,7 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.Package, output.ValidatingType);
-                Assert.Equal(null, output.PackageKey);
+                Assert.Equal(null, output.EntityKey);
             }
 
             [Theory]
@@ -133,7 +133,7 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.SymbolPackage, output.ValidatingType);
-                Assert.Equal(expectedKey, output.PackageKey);
+                Assert.Equal(expectedKey, output.EntityKey);
             }
 
             [Fact]

--- a/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
@@ -20,6 +20,7 @@ namespace NuGet.Services.Validation.Tests
         private const string PackageValidationMessageDataType = "PackageValidationMessageData";
         private const int SchemaVersion1 = 1;
         private const int DeliveryCount = 2;
+        private const int PackageKey = 123;
 
         public class TheSerializePackageValidationMessageDataMethod : Base
         {
@@ -27,7 +28,7 @@ namespace NuGet.Services.Validation.Tests
             public void ProducesExpectedMessage()
             {
                 // Arrange
-                var input = new PackageValidationMessageData(PackageId, PackageVersion, ValidationTrackingId);
+                var input = new PackageValidationMessageData(PackageId, PackageVersion, ValidationTrackingId, ValidatingType.Package, PackageKey);
 
                 // Act
                 var output = _target.SerializePackageValidationMessageData(input);
@@ -45,7 +46,7 @@ namespace NuGet.Services.Validation.Tests
             public void ProducesExpectedMessageForSymbols()
             {
                 // Arrange
-                var input = new PackageValidationMessageData(PackageId, PackageVersion, ValidationTrackingId, ValidatingType.SymbolPackage);
+                var input = new PackageValidationMessageData(PackageId, PackageVersion, ValidationTrackingId, ValidatingType.SymbolPackage, PackageKey);
 
                 // Act
                 var output = _target.SerializePackageValidationMessageData(input);
@@ -64,11 +65,24 @@ namespace NuGet.Services.Validation.Tests
         {
             private const string TypeValue = "PackageValidationMessageData";
 
-            [Fact]
-            public void ProducesExpectedMessage()
+            public static IEnumerable<object[]> SerializedTestMessageData2 = new[]
+            {
+                new object[] { TestData.SerializedPackageValidationMessageData2, PackageKey },
+                new object[] { TestData.SerializedPackageValidationMessageDataWithNoPackageKey2, null}
+            };
+
+            public static IEnumerable<object[]> SerializedTestMessageDataForSymbols = new[]
+            {
+                new object[] { TestData.SerializedPackageValidationMessageDataSymbols, PackageKey },
+                new object[] { TestData.SerializedPackageValidationMessageDataSymbolsWithNoPackageKey, null}
+            };
+
+            [Theory]
+            [MemberData(nameof(SerializedTestMessageData2))]
+            public void ProducesExpectedMessage(string serializedMessage, int? expectedKey)
             {
                 // Arrange
-                var brokeredMessage = GetBrokeredMessage();
+                var brokeredMessage = GetBrokeredMessage(serializedMessage);
 
                 // Act
                 var output = _target.DeserializePackageValidationMessageData(brokeredMessage.Object);
@@ -80,6 +94,7 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.Package, output.ValidatingType);
+                Assert.Equal(expectedKey, output.PackageKey);
             }
 
             [Fact]
@@ -98,13 +113,15 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.Package, output.ValidatingType);
+                Assert.Equal(null, output.PackageKey);
             }
 
-            [Fact]
-            public void ProducesExpectedMessageForSymbols()
+            [Theory]
+            [MemberData(nameof(SerializedTestMessageDataForSymbols))]
+            public void ProducesExpectedMessageForSymbols(string serializedMessage, int? expectedKey)
             {
                 // Arrange
-                var brokeredMessage = GetBrokeredSymbolMessage();
+                var brokeredMessage = GetBrokeredSymbolMessage(serializedMessage);
 
                 // Act
                 var output = _target.DeserializePackageValidationMessageData(brokeredMessage.Object);
@@ -116,8 +133,8 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(ValidationTrackingId, output.ValidationTrackingId);
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.SymbolPackage, output.ValidatingType);
+                Assert.Equal(expectedKey, output.PackageKey);
             }
-
 
             [Fact]
             public void RejectsInvalidType()
@@ -197,12 +214,12 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Contains($"The provided message contains a {SchemaVersionKey} property that is not an integer.", exception.Message);
             }
 
-            private static Mock<IBrokeredMessage> GetBrokeredMessage()
+            private static Mock<IBrokeredMessage> GetBrokeredMessage(string expectedMessage = null)
             {
                 var brokeredMessage = new Mock<IBrokeredMessage>();
                 brokeredMessage
                     .Setup(x => x.GetBody())
-                    .Returns(TestData.SerializedPackageValidationMessageData2);
+                    .Returns(expectedMessage ?? TestData.SerializedPackageValidationMessageData2);
                 brokeredMessage
                     .Setup(x => x.DeliveryCount)
                     .Returns(DeliveryCount);
@@ -235,12 +252,12 @@ namespace NuGet.Services.Validation.Tests
                 return brokeredMessage;
             }
 
-            private static Mock<IBrokeredMessage> GetBrokeredSymbolMessage()
+            private static Mock<IBrokeredMessage> GetBrokeredSymbolMessage(string serializedMessage = null)
             {
                 var brokeredMessage = new Mock<IBrokeredMessage>();
                 brokeredMessage
                     .Setup(x => x.GetBody())
-                    .Returns(TestData.SerializedPackageValidationMessageDataSymbols);
+                    .Returns(serializedMessage ?? TestData.SerializedPackageValidationMessageDataSymbols);
                 brokeredMessage
                     .Setup(x => x.DeliveryCount)
                     .Returns(DeliveryCount);

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0,&quot;PackageKey&quot;:null}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataPackage {
             get {
@@ -88,7 +88,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1,&quot;PackageKey&quot;:null}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataSymbols {
             get {

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -70,7 +70,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;PackageKey&quot;:123}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;EntityKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageData2 {
             get {
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0,&quot;PackageKey&quot;:123}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0,&quot;EntityKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataPackage {
             get {
@@ -88,7 +88,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1,&quot;PackageKey&quot;:123}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1,&quot;EntityKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataSymbols {
             get {

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -70,7 +70,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;PackageKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageData2 {
             get {
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0,&quot;PackageKey&quot;:null}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:0,&quot;PackageKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataPackage {
             get {
@@ -88,11 +88,38 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1,&quot;PackageKey&quot;:null}.
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1,&quot;PackageKey&quot;:123}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataSymbols {
             get {
                 return ResourceManager.GetString("SerializedPackageValidationMessageDataSymbols", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1}.
+        /// </summary>
+        internal static string SerializedPackageValidationMessageDataSymbolsWithNoPackageKey {
+            get {
+                return ResourceManager.GetString("SerializedPackageValidationMessageDataSymbolsWithNoPackageKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
+        /// </summary>
+        internal static string SerializedPackageValidationMessageDataWithNoPackageKey1 {
+            get {
+                return ResourceManager.GetString("SerializedPackageValidationMessageDataWithNoPackageKey1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
+        /// </summary>
+        internal static string SerializedPackageValidationMessageDataWithNoPackageKey2 {
+            get {
+                return ResourceManager.GetString("SerializedPackageValidationMessageDataWithNoPackageKey2", resourceCulture);
             }
         }
     }

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -99,18 +99,18 @@ namespace NuGet.Services.Validation.Tests {
         /// <summary>
         ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ValidatingType&quot;:1}.
         /// </summary>
-        internal static string SerializedPackageValidationMessageDataSymbolsWithNoPackageKey {
+        internal static string SerializedPackageValidationMessageDataSymbolsWithNoEntityKey {
             get {
-                return ResourceManager.GetString("SerializedPackageValidationMessageDataSymbolsWithNoPackageKey", resourceCulture);
+                return ResourceManager.GetString("SerializedPackageValidationMessageDataSymbolsWithNoEntityKey", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
         /// </summary>
-        internal static string SerializedPackageValidationMessageDataWithNoPackageKey2 {
+        internal static string SerializedPackageValidationMessageDataWithNoEntityKey2 {
             get {
-                return ResourceManager.GetString("SerializedPackageValidationMessageDataWithNoPackageKey2", resourceCulture);
+                return ResourceManager.GetString("SerializedPackageValidationMessageDataWithNoEntityKey2", resourceCulture);
             }
         }
     }

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -106,15 +106,6 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
-        /// </summary>
-        internal static string SerializedPackageValidationMessageDataWithNoPackageKey1 {
-            get {
-                return ResourceManager.GetString("SerializedPackageValidationMessageDataWithNoPackageKey1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {&quot;PackageId&quot;:&quot;NuGet.Versioning&quot;,&quot;PackageVersion&quot;:&quot;4.3&quot;,&quot;PackageNormalizedVersion&quot;:&quot;4.3.0&quot;,&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;}.
         /// </summary>
         internal static string SerializedPackageValidationMessageDataWithNoPackageKey2 {

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -129,10 +129,10 @@
   <data name="SerializedPackageValidationMessageDataSymbols" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"EntityKey":123}</value>
   </data>
-  <data name="SerializedPackageValidationMessageDataSymbolsWithNoPackageKey" xml:space="preserve">
+  <data name="SerializedPackageValidationMessageDataSymbolsWithNoEntityKey" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1}</value>
   </data>
-  <data name="SerializedPackageValidationMessageDataWithNoPackageKey2" xml:space="preserve">
+  <data name="SerializedPackageValidationMessageDataWithNoEntityKey2" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>
 </root>

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -124,9 +124,9 @@
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataPackage" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0,"PackageKey":null}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataSymbols" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"PackageKey":null}</value>
   </data>
 </root>

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -121,12 +121,21 @@
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>
   <data name="SerializedPackageValidationMessageData2" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","PackageKey":123}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataPackage" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0,"PackageKey":null}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0,"PackageKey":123}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataSymbols" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"PackageKey":null}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"PackageKey":123}</value>
+  </data>
+  <data name="SerializedPackageValidationMessageDataSymbolsWithNoPackageKey" xml:space="preserve">
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1}</value>
+  </data>
+  <data name="SerializedPackageValidationMessageDataWithNoPackageKey1" xml:space="preserve">
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
+  </data>
+  <data name="SerializedPackageValidationMessageDataWithNoPackageKey2" xml:space="preserve">
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>
 </root>

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -121,13 +121,13 @@
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>
   <data name="SerializedPackageValidationMessageData2" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","PackageKey":123}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","EntityKey":123}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataPackage" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0,"PackageKey":123}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":0,"EntityKey":123}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataSymbols" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"PackageKey":123}</value>
+    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1,"EntityKey":123}</value>
   </data>
   <data name="SerializedPackageValidationMessageDataSymbolsWithNoPackageKey" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1}</value>

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -132,9 +132,6 @@
   <data name="SerializedPackageValidationMessageDataSymbolsWithNoPackageKey" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ValidatingType":1}</value>
   </data>
-  <data name="SerializedPackageValidationMessageDataWithNoPackageKey1" xml:space="preserve">
-    <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
-  </data>
   <data name="SerializedPackageValidationMessageDataWithNoPackageKey2" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
   </data>


### PR DESCRIPTION
We need to pass `PackageKey` in the message from gallery so that `Orchestrator` can perform appropriate actions for revalidating a symbols package. The idea is we will not pass `PackageKey`(or null) in the message when a package is pushed for validation(first time) with revalidation we will pass in the `Key` for the entity. 

I am open to generalizing this and naming it `EntityKey` or `Key`, I kept it `PackageKey` in context to that of the `PackageId` and `PackageVersion` in the message.