### PR TITLE
Changes to signing targets for job MicroBuild integration

### DIFF
--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
+  "MicroBuild_NuPkgSigningEnabled" configures whether or not .nupkg files built will be signed.
+  We are not required to sign the .nupkg files we produce, so we must set it to false.
+  -->
+  <PropertyGroup>
+    <MicroBuild_NuPkgSigningEnabled>false</MicroBuild_NuPkgSigningEnabled>
+  </PropertyGroup>
+  <!--
   "EnumerateFilesToSign" is a custom target that runs after build and signs the output assembly of the project. This
   target only runs if the "SignAssembly" is true (which enables delayed signing) and if "SignType" is not "none". This
   latter condition is to allow builds to disable signing explicitly, which is an optimization for Cloud Service builds.
   Cloud Service builds do a solution build then a "Publish" on the .ccproj. Only that "Publish" step needs to sign
   things.
   -->
-  <PropertyGroup>
-    <MicroBuild_NuPkgSigningEnabled>false</MicroBuild_NuPkgSigningEnabled>
-  </PropertyGroup>
   <ItemGroup>
     <SignFilesDependsOn Include="EnumerateFilesToSign" />
   </ItemGroup>

--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -8,7 +8,7 @@
   things.
   -->
   <PropertyGroup>
-    <MicroBuild_NuPkgSigningEnabled>false<MicroBuild_NuPkgSigningEnabled/>
+    <MicroBuild_NuPkgSigningEnabled>false</MicroBuild_NuPkgSigningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <SignFilesDependsOn Include="EnumerateFilesToSign" />

--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -7,8 +7,10 @@
   Cloud Service builds do a solution build then a "Publish" on the .ccproj. Only that "Publish" step needs to sign
   things.
   -->
-  <ItemGroup>
+  <PropertyGroup>
     <MicroBuild_NuPkgSigningEnabled>false<MicroBuild_NuPkgSigningEnabled/>
+  </PropertyGroup>
+  <ItemGroup>
     <SignFilesDependsOn Include="EnumerateFilesToSign" />
   </ItemGroup>
   <Target Name="EnumerateFilesToSign" AfterTargets="AfterBuild" Condition="'$(SignAssembly)' == 'true' AND '$(SignType)' != 'none'">

--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -8,6 +8,7 @@
   things.
   -->
   <ItemGroup>
+    <MicroBuild_NuPkgSigningEnabled>false<MicroBuild_NuPkgSigningEnabled/>
     <SignFilesDependsOn Include="EnumerateFilesToSign" />
   </ItemGroup>
   <Target Name="EnumerateFilesToSign" AfterTargets="AfterBuild" Condition="'$(SignAssembly)' == 'true' AND '$(SignType)' != 'none'">

--- a/build/sign.scripts.targets
+++ b/build/sign.scripts.targets
@@ -1,7 +1,7 @@
 <Project>
   <!--
   "EnumerateScriptFilesToSign" is a custom target that signs deployment scripts and executables.
-  The process is non-trivial because only files in $(OutDir) can be signed..
+  The process is non-trivial because only files in $(OutDir) can be signed.
   We must copy the files into $(OutDir), sign them, and then copy them back.
   -->
   <ItemGroup>

--- a/build/sign.scripts.targets
+++ b/build/sign.scripts.targets
@@ -23,15 +23,15 @@
       <ScriptsToSign Include="@(ExecutablesToSign)"/>
     </ItemGroup>
     <!-- Copy the files into $(OutDir) where they can be signed. -->
-    <Copy
+    <Copy Condition="'@(ScriptsToSign)'!=''"
       SourceFiles="$(MSBuildProjectDirectory)\Scripts\%(ScriptsToSign.Identity)"
       DestinationFolder="$(OutDir)"
     />
     <ItemGroup>
-      <FilesToSign Include="$(OutDir)%(PowerShellScriptsToSign.Identity)">
+      <FilesToSign Condition="'@(PowerShellScriptsToSign)'!=''" Include="$(OutDir)%(PowerShellScriptsToSign.Identity)">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(OutDir)%(ExecutablesToSign.Identity)">
+      <FilesToSign Condition="'@(ExecutablesToSign)'!=''" Include="$(OutDir)%(ExecutablesToSign.Identity)">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
     </ItemGroup>
@@ -39,11 +39,11 @@
   </Target>
   <Target Name="CleanUpScriptFilesToSign" AfterTargets="SignFiles" Condition="'$(SignType)' != 'none'">
     <!-- Copy the signed files from $(OutDir) back to the Scripts folder. -->
-    <Copy
+    <Copy Condition="'@(ScriptsToSign)'!=''"
       SourceFiles="$(OutDir)%(ScriptsToSign.Identity)"
       DestinationFolder="$(MSBuildProjectDirectory)\Scripts"
     />
     <!-- The copy of the files in $(OutDir) can now be deleted. -->
-    <Delete Files="$(OutDir)%(ScriptsToSign.Identity)"/>
+    <Delete Condition="'@(ScriptsToSign)'!=''" Files="$(OutDir)%(ScriptsToSign.Identity)"/>
   </Target>
 </Project>

--- a/build/sign.scripts.targets
+++ b/build/sign.scripts.targets
@@ -12,9 +12,11 @@
       <PowerShellScriptsToSign Include="Functions.ps1"/>
       <PowerShellScriptsToSign Include="PostDeploy.ps1"/>
       <PowerShellScriptsToSign Include="PreDeploy.ps1"/>
+      <PowerShellScriptsToSign Remove="@(PowerShellScriptsToNotSign)"/>
     </ItemGroup>
     <ItemGroup>
       <ExecutablesToSign Include="nssm.exe"/>
+      <ExecutablesToSign Remove="@(ExecutablesToNotSign)"/>
     </ItemGroup>
     <ItemGroup>
       <ScriptsToSign Include="@(PowerShellScriptsToSign)"/>

--- a/build/sign.scripts.targets
+++ b/build/sign.scripts.targets
@@ -1,0 +1,47 @@
+<Project>
+  <!--
+  "EnumerateScriptFilesToSign" is a custom target that signs deployment scripts and executables.
+  The process is non-trivial because only files in $(OutDir) can be signed..
+  We must copy the files into $(OutDir), sign them, and then copy them back.
+  -->
+  <ItemGroup>
+    <SignFilesDependsOn Include="EnumerateScriptFilesToSign" />
+  </ItemGroup>
+  <Target Name="EnumerateScriptFilesToSign" AfterTargets="AfterBuild" Condition="'$(SignType)' != 'none'">
+    <ItemGroup>
+      <PowerShellScriptsToSign Include="Functions.ps1"/>
+      <PowerShellScriptsToSign Include="PostDeploy.ps1"/>
+      <PowerShellScriptsToSign Include="PreDeploy.ps1"/>
+    </ItemGroup>
+    <ItemGroup>
+      <ExecutablesToSign Include="nssm.exe"/>
+    </ItemGroup>
+    <ItemGroup>
+      <ScriptsToSign Include="@(PowerShellScriptsToSign)"/>
+      <ScriptsToSign Include="@(ExecutablesToSign)"/>
+    </ItemGroup>
+    <!-- Copy the files into $(OutDir) where they can be signed. -->
+    <Copy
+      SourceFiles="$(MSBuildProjectDirectory)\Scripts\%(ScriptsToSign.Identity)"
+      DestinationFolder="$(OutDir)"
+    />
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)%(PowerShellScriptsToSign.Identity)">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(OutDir)%(ExecutablesToSign.Identity)">
+        <Authenticode>3PartySHA2</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Text="Files to sign:%0A@(FilesToSign, '%0A')" Importance="High" />
+  </Target>
+  <Target Name="CleanUpScriptFilesToSign" AfterTargets="SignFiles" Condition="'$(SignType)' != 'none'">
+    <!-- Copy the signed files from $(OutDir) back to the Scripts folder. -->
+    <Copy
+      SourceFiles="$(OutDir)%(ScriptsToSign.Identity)"
+      DestinationFolder="$(MSBuildProjectDirectory)\Scripts"
+    />
+    <!-- The copy of the files in $(OutDir) can now be deleted. -->
+    <Delete Files="$(OutDir)%(ScriptsToSign.Identity)"/>
+  </Target>
+</Project>


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/1728

This PR consists of two changes:
1 - We need to set `MicroBuild_NuPkgSigningEnabled` to false so that it doesn't automatically sign the nupkgs we produce (we are not required to sign them).
2 - Adding `sign.scripts.targets` that will be used by both `NuGet.Services.Metadata` and `NuGet.Jobs` to sign the `Scripts\` files.