### PR TITLE
Fix GetTypes exception when AzureRm modules loaded

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -89,11 +89,9 @@ Function Get-MSBuildExe {
         $MSBuildPath = Join-Path $MSBuildExe $MSBuildExeRelPath
     } else {
         # Check if VS package to use to find $NuGetBuildPackageId is installed. If not, install it.
-        if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | `
-            ForEach-Object { $_.GetTypes() } | `
-            Where-Object { `
-                $_.FullName -like "NuGet.Services.Build.VisualStudioSetupConfigurationHelper" `
-            }))
+        $buildPackageFound = [System.AppDomain]::CurrentDomain.GetAssemblies() | `
+            Where-Object { $_.FullName -like "$($NuGetBuildPackageId), *" }
+        if (-not $buildPackageFound)
         {
             Trace-Log "Installing and configuring $NuGetBuildPackageId"
             $opts = "install", $NuGetBuildPackageId, `


### PR DESCRIPTION
I'm seeing `build.ps1` throw when certain AzureRm modules are loaded. The cause appears to be a dependency conflict for assembly `Microsoft.WindowsAzure.Storage`. Suggested fix is to not enumerate types, just check if the build assembly is loaded.

**Failing Assemblies:**
- C:\Program Files\WindowsPowerShell\Modules\AzureRM.RedisCache\4.1.2\Microsoft.Azure.Insights.dll
- C:\Program Files\WindowsPowerShell\Modules\Azure\5.1.2\HDInsight\Microsoft.Hadoop.Client.dll

**Repro (Step 3 from `common.ps1`):**
> \> Get-Module
> \> Get-Command -Module AzureRm | Out-Null
> \> [AppDomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $a = $_; try { $a.GetTypes()>$null } catch { Write-Host $_; Write-Host $a.Location } } >$null
> \> Get-module

**Exception:**
BUILD FAILED: Exception calling "GetTypes" with "0" argument(s): "Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more infor
mation."
ERROR DETAILS:
System.Management.Automation.MethodInvocationException: Exception calling "GetTypes" with "0" argument(s): "Unable to load one or more of the requested types. Retrieve th
e LoaderExceptions property for more information." ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the Loa
derExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at CallSite.Target(Closure , CallSite , Object )
   --- End of inner exception stack trace ---
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at <ScriptBlock>(Closure , FunctionContext )
   at System.Management.Automation.ScriptBlock.InvokeWithPipeImpl(ScriptBlockClauseToInvoke clauseToInvoke, Boolean createLocalScope, Dictionary`2 functionsToDefine, List
`1 variablesToDefine, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Ob
ject[] args)
   at System.Management.Automation.ScriptBlock.<>c__DisplayClass57_0.<InvokeWithPipe>b__0()
   at System.Management.Automation.Runspaces.RunspaceBase.RunActionIfNoRunningPipelinesWithThreadCheck(Action action)
   at System.Management.Automation.ScriptBlock.InvokeWithPipe(Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUnder, Object input, Object
 scriptThis, Pipe outputPipe, InvocationInfo invocationInfo, Boolean propagateAllExceptionsToTop, List`1 variablesToDefine, Dictionary`2 functionsToDefine, Object[] args)
   at System.Management.Automation.ScriptBlock.InvokeUsingCmdlet(Cmdlet contextCmdlet, Boolean useLocalScope, ErrorHandlingBehavior errorHandlingBehavior, Object dollarUn
der, Object input, Object scriptThis, Object[] args)
   at Microsoft.PowerShell.Commands.ForEachObjectCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()