### PR TITLE
FxCop override support and fixes

### DIFF
--- a/build/NuGet.Sdl7.0.ruleset
+++ b/build/NuGet.Sdl7.0.ruleset
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Based on SDL7.0.ruleset. Exceptions commented inline, keep as close to original as possible. -->
+<RuleSet Name="NuGet SDL 7.0" Description="Based on SDL 7.0-prescribed required and recommended checks." ToolsVersion="11.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+     <Rule Id="CA3102" Action="Warning" />
+     <Rule Id="CA3103" Action="Error" />
+     <Rule Id="CA3104" Action="Warning" />
+     <Rule Id="CA3105" Action="Error" />
+     <Rule Id="CA3106" Action="Error" />
+     <Rule Id="CA3107" Action="Warning" />
+     <Rule Id="CA3108" Action="Warning" />
+     <Rule Id="CA3109" Action="Warning" />
+     <Rule Id="CA3110" Action="Error" />
+     <Rule Id="CA3111" Action="Warning" />
+     <Rule Id="CA3112" Action="Warning" />
+     <Rule Id="CA3113" Action="Error" />
+     <Rule Id="CA3114" Action="Error" />
+     <Rule Id="CA3115" Action="Warning" />
+     <Rule Id="CA3116" Action="Error" />
+     <Rule Id="CA3117" Action="Warning" />
+     <Rule Id="CA3118" Action="Warning" />
+     <Rule Id="CA3119" Action="Error" />
+     <Rule Id="CA3120" Action="Warning" />
+     <Rule Id="CA3121" Action="Warning" />
+     <Rule Id="CA3122" Action="Warning" />
+     <Rule Id="CA3123" Action="Error" />
+     <Rule Id="CA3124" Action="Error" />
+     <Rule Id="CA3125" Action="Error" />
+     <Rule Id="CA3127" Action="Error" />
+     <Rule Id="CA3129" Action="Warning" />
+     <Rule Id="CA3130" Action="Warning" />
+     <Rule Id="CA3131" Action="Warning" />
+     <Rule Id="CA3132" Action="Warning" />
+     <Rule Id="CA3133" Action="Warning" />
+     <Rule Id="CA3134" Action="Warning" />
+     <Rule Id="CA3135" Action="Error" />
+     <Rule Id="CA3137" Action="Warning" />
+     <Rule Id="CA3138" Action="Warning" />
+     <Rule Id="CA3139" Action="Warning" />
+     <Rule Id="CA3140" Action="Warning" />
+     <Rule Id="CA3141" Action="Warning" />
+     <Rule Id="CA3142" Action="Error" />
+     <Rule Id="CA3143" Action="Warning" />
+     <Rule Id="CA3145" Action="Warning" />
+     <Rule Id="CA3146" Action="Warning" />
+     <Rule Id="CA3147" Action="Error" />
+     <Rule Id="CA3001" Action="Error" />
+     <Rule Id="CA3002" Action="Warning" />
+     <Rule Id="CA3003" Action="Error" />
+     <Rule Id="CA3004" Action="Error" />
+     <Rule Id="CA3005" Action="Warning" />
+     <Rule Id="CA3006" Action="Error" />
+     <Rule Id="CA3007" Action="Warning" />
+     <Rule Id="CA3008" Action="Warning" />
+     <Rule Id="CA3009" Action="Warning" />
+     <Rule Id="CA3010" Action="Warning" />
+     <Rule Id="CA3011" Action="Error" />
+     <Rule Id="CA3012" Action="Error" />
+     <Rule Id="CA2100" Action="Error" />
+     <Rule Id="CA5350" Action="Error" />
+     <Rule Id="CA5351" Action="Error" />
+     <Rule Id="CA5352" Action="Error" />
+     <Rule Id="CA5353" Action="Error" />
+     <Rule Id="CA5354" Action="Error" />
+     <Rule Id="CA5355" Action="Error" />
+     <Rule Id="CA5356" Action="Error" />
+     <Rule Id="CA5357" Action="Error" />
+<!-- Microsoft.Globalization #CA1304:SpecifyCultureInfo-->
+<!-- <Rule Id="CA1304" Action="Warning" /> -->
+<!-- Microsoft.Globalization #CA1305:SpecifyIFormatProvider -->
+<!-- <Rule Id="CA1305" Action="Warning" /> -->
+<!-- Microsoft.Globalization #CA1307:SpecifyStringComparison -->
+<!-- <Rule Id="CA1307" Action="Warning" /> -->
+<!-- Microsoft.Globalization #CA1309:UseOrdinalStringComparison -->
+<!-- <Rule Id="CA1309" Action="Warning" /> -->
+     <Rule Id="CA2101" Action="Warning" />
+     <Rule Id="CA1401" Action="Warning" />
+     <Rule Id="CA900" Action="Error" />
+     <Rule Id="CA2001" Action="Warning" />
+     <Rule Id="CA2102" Action="Warning" />
+     <Rule Id="CA2103" Action="Warning" />
+<!-- Microsoft.Security #CA2104:DoNotDeclareReadOnlyMutableReferenceTypes -->
+<!-- <Rule Id="CA2104" Action="Warning" /> -->
+     <Rule Id="CA2105" Action="Warning" />
+     <Rule Id="CA2106" Action="Error" />
+     <Rule Id="CA2107" Action="Warning" />
+     <Rule Id="CA2108" Action="Warning" />
+     <Rule Id="CA2109" Action="Warning" />
+     <Rule Id="CA2111" Action="Error" />
+     <Rule Id="CA2112" Action="Warning" />
+     <Rule Id="CA2114" Action="Warning" />
+     <Rule Id="CA2115" Action="Warning" />
+     <Rule Id="CA2116" Action="Warning" />
+     <Rule Id="CA2117" Action="Error" />
+     <Rule Id="CA2118" Action="Error" />
+     <Rule Id="CA2119" Action="Error" />
+     <Rule Id="CA2120" Action="Error" />
+     <Rule Id="CA2121" Action="Warning" />
+     <Rule Id="CA2122" Action="Warning" />
+     <Rule Id="CA2124" Action="Error" />
+     <Rule Id="CA2126" Action="Error" />
+     <Rule Id="CA3050" Action="Error" />
+     <Rule Id="CA3053" Action="Error" />
+     <Rule Id="CA3054" Action="Error" />
+     <Rule Id="CA3055" Action="Error" />
+     <Rule Id="CA3056" Action="Error" />
+     <Rule Id="CA3057" Action="Error" />
+     <Rule Id="CA3058" Action="Error" />
+     <Rule Id="CA3059" Action="Error" />
+     <Rule Id="CA3060" Action="Error" />
+     <Rule Id="CA3061" Action="Error" />
+     <Rule Id="CA3062" Action="Error" />
+     <Rule Id="CA3063" Action="Error" />
+     <Rule Id="CA3064" Action="Error" />
+     <Rule Id="CA3065" Action="Error" />
+     <Rule Id="CA3066" Action="Error" />
+     <Rule Id="CA3067" Action="Error" />
+     <Rule Id="CA3068" Action="Error" />
+     <Rule Id="CA3069" Action="Error" />
+     <Rule Id="CA3070" Action="Error" />
+     <Rule Id="CA3071" Action="Error" />
+     <Rule Id="CA3072" Action="Error" />
+     <Rule Id="CA3073" Action="Error" />
+     <Rule Id="CA3074" Action="Error" />
+     <Rule Id="CA2153" Action="Error" />
+  </Rules>
+</RuleSet>

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -266,12 +266,16 @@ Function Invoke-FxCop {
         }
         
         if ($FxCopRuleSet) {
-            $items = Get-ChildItem $(Join-Path $FxCopDirectory $FxCopRuleSet) -Recurse
+            # To support overrides, look for ruleset in build tools first and then fxcop directory.
+            $items = Get-ChildItem $(Join-Path $PSScriptRoot $FxCopRuleSet) -Recurse
+            if ($items.Count -eq 0) {
+                $items = Get-ChildItem $(Join-Path $FxCopDirectory $FxCopRuleSet) -Recurse
+            }
             
             if ($items.Count -gt 0) {
                 $env:FXCOP_RULESET = $items[0]
                 $env:FXCOP_RULESET_DIRECTORY = $($items[0]).Directory
-                Trace-Log "Discovered FXCOP_RULESET=$FxCopRuleSetFullPath"
+                Trace-Log "Discovered FXCOP_RULESET=$($items[0])"
             }
             else {
                 throw "Failed to find $FxCopRuleSet under $FxCopDirectory"

--- a/src/NuGet.Services.AzureManagement/AzureHelper.cs
+++ b/src/NuGet.Services.AzureManagement/AzureHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
 using Newtonsoft.Json.Linq;
@@ -76,6 +77,7 @@ namespace NuGet.Services.AzureManagement
             }
         }
 
+        [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver", Justification = @"FxCop incorrectly reports that XmlResolver should be null on XmlReaderSettings and XmlDocument.")]
         /// <summary>
         /// Parses the result of https://management.azure.com/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ClassicCompute/domainNames/{2}/slots/{3}?api-version=2016-11-01
         /// </summary>
@@ -95,7 +97,8 @@ namespace NuGet.Services.AzureManagement
                 {
                     var settings = new XmlReaderSettings()
                     {
-                        DtdProcessing = DtdProcessing.Prohibit
+                        DtdProcessing = DtdProcessing.Prohibit,
+                        XmlResolver = null
                     };
 
                     using (var xmlReader = XmlReader.Create(stringReader, settings))


### PR DESCRIPTION
Tracking: https://github.com/NuGet/Engineering/issues/1757

**Includes:**
- Add support for SDL ruleset overrides (currently ignoring CA1305 and CA1307 due to volume)
  - Builds will have "FxCopRuleSet" parameter, and overrides applied to highest volume repos
- Suppress **Microsoft.Security #CA3053:UseXmlSecureResolver** errors, which fxcop incorrectly reports
- Fix the following warnings:
  - **Microsoft.Security #CA2104:DoNotDeclareReadOnlyMutableReferenceTypes**
  - **Microsoft.Globalization #CA1304:SpecifyCultureInfo**
  - **Microsoft.Globalization #CA1309:UseOrdinalStringComparison**

**Summary of TSA issues:**
- **Microsoft.Globalization #CA1304:SpecifyCultureInfo**
    - Total: 20
    - NuGetGallery: 10
    - NuGet.Services.Metadata: 9
    - ServerCommon: 1 (fixed here)
- **Microsoft.Globalization #CA1305:SpecifyIFormatProvider**
    - Total: 496
    - NuGet.Services.Metadata: 225 (will ignore)
    - NuGetGallery: 192 (will ignore)
    - NuGet.Jobs: 41 (may ignore)
    - ServerCommon: 38 (will ignore, requires net46/FormattableString.Invariant to fix interpolated strings)
- **Microsoft.Globalization #CA1307:SpecifyStringComparison**
    - Total: 125
    - NuGet.Services.Metadata: 52 (will ignore)
    - NuGet.Jobs: 36 (may ignore)
    - NuGetGallery: 30 (will ignore)
    - ServerCommon: 7 (fixed, but also ignored w/ CA1304)
- **Microsoft.Globalization #CA1309:UseOrdinalStringComparison**
    - Total: 46
    - NuGet.Services.Metadata: 20
    - NuGetGallery: 12
    - NuGet.Jobs: 12
    - ServerCommon: 2 (fixed here)