### PR TITLE
Add CA2105 exclusion

### DIFF
--- a/build/NuGet.Sdl7.0.ruleset
+++ b/build/NuGet.Sdl7.0.ruleset
@@ -81,7 +81,8 @@
      <Rule Id="CA2103" Action="Warning" />
 <!-- Microsoft.Security #CA2104:DoNotDeclareReadOnlyMutableReferenceTypes -->
 <!-- <Rule Id="CA2104" Action="Warning" /> -->
-     <Rule Id="CA2105" Action="Warning" />
+<!-- Microsoft.Security #CA2105:ArrayFieldsShouldNotBeReadOnly -->
+<!-- <Rule Id="CA2105" Action="Warning" /> -->
      <Rule Id="CA2106" Action="Error" />
      <Rule Id="CA2107" Action="Warning" />
      <Rule Id="CA2108" Action="Warning" />


### PR DESCRIPTION
Exclude **CA2105:ArrayFieldsShouldNotBeReadOnly**, for NuGet.Services.Metadata and NuGet.Internal.Jobs

Similar to **CA2104:DoNotDeclareReadOnlyMutableReferenceTypes**, but for array types.

