### PR TITLE
Divided symbol error message

### DIFF
--- a/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
+++ b/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
@@ -69,7 +69,7 @@ namespace NuGet.Services.Validation
         SymbolErrorCode_ChecksumDoesNotMatch = 250,
 
         /// <summary>
-        /// The pdb is not portable or did not have a binary assembly file associated.
+        /// The pdb does not have a binary assembly file associated.
         /// </summary>
         SymbolErrorCode_MatchingAssemblyNotFound = 251,
 

--- a/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
+++ b/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
@@ -71,7 +71,12 @@ namespace NuGet.Services.Validation
         /// <summary>
         /// The pdb is not portable or did not have a binary assembly file associated.
         /// </summary>
-        SymbolErrorCode_MatchingPortablePDBNotFound = 251,
+        SymbolErrorCode_MatchingAssemblyNotFound = 251,
+
+        /// <summary>
+        /// The pdb is not portable.
+        /// </summary>
+        SymbolErrorCode_PdbIsNotPortable = 252,
         #endregion 
 
         /// <summary>

--- a/src/NuGet.Services.Messaging.Email/Extensions/ValidationIssueExtensions.cs
+++ b/src/NuGet.Services.Messaging.Email/Extensions/ValidationIssueExtensions.cs
@@ -55,8 +55,10 @@ namespace NuGet.Services.Messaging.Email
                     return $"The package was signed, but the signing certificate {(certIssue != null ? $"(SHA-1 thumbprint {certIssue.Sha1Thumbprint})" : "")} is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
                 case ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch:
                     return "The checksum does not match for the dll(s) and corresponding pdb(s).";
-                case ValidationIssueCode.SymbolErrorCode_MatchingPortablePDBNotFound:
+                case ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound:
                     return "The uploaded symbols package contains pdb(s) for a corresponding dll(s) not found in the nuget package.";
+                case ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable:
+                    return "The uploaded symbols package contains one or more pdbs that are not portable.";
                 default:
                     return "There was an unknown failure when validating your package.";
             }

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -46,8 +46,8 @@ namespace NuGet.Services.Validation.Issues
             ValidationIssueCode.OnlySignatureFormatVersion1Supported,
             ValidationIssueCode.AuthorCounterSignaturesNotSupported,
             ValidationIssueCode.PackageIsNotSigned,
-            ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound,
             ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch,
+            ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound,
             ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable
         };
 

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -18,7 +18,8 @@ namespace NuGet.Services.Validation.Issues
         public static ValidationIssue AuthorCounterSignaturesNotSupported { get; } = new NoDataValidationIssue(ValidationIssueCode.AuthorCounterSignaturesNotSupported);
         public static ValidationIssue PackageIsNotSigned { get; } = new NoDataValidationIssue(ValidationIssueCode.PackageIsNotSigned);
         public static ValidationIssue SymbolErrorCode_ChecksumDoesNotMatch { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch);
-        public static ValidationIssue SymbolErrorCode_MatchingPortablePDBNotFound { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_MatchingPortablePDBNotFound);
+        public static ValidationIssue SymbolErrorCode_MatchingAssemblyNotFound { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound);
+        public static ValidationIssue SymbolErrorCode_PdbIsNotPortable { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable);
 
         /// <summary>
         /// The map of issue codes to the type that represents the issues. The types MUST extend <see cref="ValidationIssue"/>.
@@ -45,8 +46,9 @@ namespace NuGet.Services.Validation.Issues
             ValidationIssueCode.OnlySignatureFormatVersion1Supported,
             ValidationIssueCode.AuthorCounterSignaturesNotSupported,
             ValidationIssueCode.PackageIsNotSigned,
-            ValidationIssueCode.SymbolErrorCode_MatchingPortablePDBNotFound,
-            ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch
+            ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound,
+            ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch,
+            ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable
         };
 
         /// <summary>

--- a/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
@@ -23,7 +23,8 @@ namespace NuGet.Services.Validation
             { 8, ValidationIssueCode.PackageIsNotSigned },
             { 9, ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate },
             { 250, ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch },
-            { 251, ValidationIssueCode.SymbolErrorCode_MatchingPortablePDBNotFound },
+            { 251, ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound},
+            { 252, ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable},
 #pragma warning disable 618
             { 9999, ValidationIssueCode.ObsoleteTesting },
 #pragma warning restore 618

--- a/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
@@ -244,7 +244,8 @@ namespace NuGet.Services.Validation.Issues.Tests
             { ValidationIssueCode.AuthorCounterSignaturesNotSupported, () => ValidationIssue.AuthorCounterSignaturesNotSupported },
             { ValidationIssueCode.PackageIsNotSigned, () => ValidationIssue.PackageIsNotSigned },
             { ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch, () => ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch },
-            { ValidationIssueCode.SymbolErrorCode_MatchingPortablePDBNotFound, () => ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound }
+            { ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound, () => ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound },
+            { ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable, () => ValidationIssue.SymbolErrorCode_PdbIsNotPortable }
         };
     }
 }


### PR DESCRIPTION
On error was used for both cases: when the pdb is not portable or when a pdb did not have a corresponding dll.  Split the error is two.