### PR TITLE
Improve signing time of ServerCommon

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,35 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -SkipRestore:$SkipRestore
+        Build-Solution $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore
+    } `
+    -ev +BuildErrors
+    
+Invoke-BuildStep 'Creating artifacts' { `
+        $projects = `
+            "src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj", `
+            "src\NuGet.Services.Logging\NuGet.Services.Logging.csproj", `
+            "src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj", `
+            "src\NuGet.Services.Build\NuGet.Services.Build.csproj", `
+            "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj", `
+            "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj", `
+            "src\NuGet.Services.Owin\NuGet.Services.Owin.csproj", `
+            "src\NuGet.Services.AzureManagement\NuGet.Services.AzureManagement.csproj", `
+            "src\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj", `
+            "src\NuGet.Services.ServiceBus\NuGet.Services.ServiceBus.csproj", `
+            "src\NuGet.Services.Validation\NuGet.Services.Validation.csproj", `
+            "src\NuGet.Services.Validation.Issues\NuGet.Services.Validation.Issues.csproj", `
+            "src\NuGet.Services.Incidents\NuGet.Services.Incidents.csproj", `
+            "src\NuGet.Services.Sql\NuGet.Services.Sql.csproj", `
+            "src\NuGet.Services.Status\NuGet.Services.Status.csproj", `
+            "src\NuGet.Services.Status.Table\NuGet.Services.Status.Table.csproj",
+            "src\NuGet.Services.Messaging\NuGet.Services.Messaging.csproj",
+            "src\NuGet.Services.Messaging.Email\NuGet.Services.Messaging.Email.csproj",
+            "src\NuGet.Services.Entities\NuGet.Services.Entities.csproj"
+            
+        $projects | ForEach-Object {
+            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId
+        }
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign
+        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign -SkipRestore:$SkipRestore
+        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -SkipRestore:$SkipRestore
+        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,35 +93,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        Build-Solution $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore
-    } `
-    -ev +BuildErrors
-    
-Invoke-BuildStep 'Creating artifacts' { `
-        $projects = `
-            "src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj", `
-            "src\NuGet.Services.Logging\NuGet.Services.Logging.csproj", `
-            "src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj", `
-            "src\NuGet.Services.Build\NuGet.Services.Build.csproj", `
-            "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj", `
-            "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj", `
-            "src\NuGet.Services.Owin\NuGet.Services.Owin.csproj", `
-            "src\NuGet.Services.AzureManagement\NuGet.Services.AzureManagement.csproj", `
-            "src\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj", `
-            "src\NuGet.Services.ServiceBus\NuGet.Services.ServiceBus.csproj", `
-            "src\NuGet.Services.Validation\NuGet.Services.Validation.csproj", `
-            "src\NuGet.Services.Validation.Issues\NuGet.Services.Validation.Issues.csproj", `
-            "src\NuGet.Services.Incidents\NuGet.Services.Incidents.csproj", `
-            "src\NuGet.Services.Sql\NuGet.Services.Sql.csproj", `
-            "src\NuGet.Services.Status\NuGet.Services.Status.csproj", `
-            "src\NuGet.Services.Status.Table\NuGet.Services.Status.Table.csproj",
-            "src\NuGet.Services.Messaging\NuGet.Services.Messaging.csproj",
-            "src\NuGet.Services.Messaging.Email\NuGet.Services.Messaging.Email.csproj",
-            "src\NuGet.Services.Entities\NuGet.Services.Entities.csproj"
-            
-        $projects | ForEach-Object {
-            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId
-        }
+        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,7 @@ Invoke-BuildStep 'Restoring solution packages' { `
         
 Invoke-BuildStep 'Building solution' { `
         $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign -SkipRestore:$SkipRestore
+        New-ProjectPackage $SolutionPath -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId -MSBuildVersion "15" -Sign
     } `
     -ev +BuildErrors
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -194,6 +194,7 @@ Function Build-Solution {
     # Build the solution
     $opts = , $SolutionPath
     $opts += "/p:Configuration=$Configuration;BuildNumber=$(Format-BuildNumber $BuildNumber)"
+    $opts += "/m"
     
     if ($TargetProfile) {
         $opts += "/p:TargetProfile=$TargetProfile"
@@ -201,10 +202,6 @@ Function Build-Solution {
     
     if ($Target) {
         $opts += "/t:$Target"
-    }
-    
-    if (-not $VerbosePreference) {
-        $opts += '/verbosity:minimal'
     }
     
     if ($MSBuildProperties) {
@@ -409,13 +406,6 @@ Function Configure-NuGetCredentials {
 
     $opts = 'sources', 'update', '-NonInteractive', '-Name', "${FeedName}", '-Username', "${Username}"
 
-    if (-not $VerbosePreference) {
-        $opts += '-verbosity', 'quiet'
-    }
-    else {
-        $opts += '-verbosity', 'detailed'
-    }
-
     if ($PAT) {
         $opts += '-Password', "${PAT}"
     }
@@ -495,10 +485,6 @@ Function Install-SolutionPackages {
         $opts += $SolutionPath
         $InstallLocation = Split-Path -Path $SolutionPath -Parent
     }
-
-    if (-not $VerbosePreference) {
-        $opts += '-verbosity', 'quiet'
-    }
     
     if ($ConfigFile) {
         $opts += '-configfile', $ConfigFile
@@ -548,10 +534,6 @@ Function Restore-SolutionPackages {
     
     if ($ConfigFile) {
         $opts += '-configfile', $ConfigFile
-    }
-
-    if (-not $VerbosePreference) {
-        $opts += '-verbosity', 'quiet'
     }
 
     Trace-Log "Restoring packages @""$InstallLocation"""
@@ -670,7 +652,8 @@ Function New-ProjectPackage {
         [string]$MSBuildVersion = $DefaultMSBuildVersion,
         [switch]$Symbols,
         [string]$Branch,
-        [switch]$IncludeReferencedProjects
+        [switch]$IncludeReferencedProjects,
+        [switch]$Sign
     )
     Trace-Log "Creating package from @""$TargetFilePath"""
     
@@ -681,6 +664,11 @@ Function New-ProjectPackage {
     
     $opts += "/p:Configuration=$Configuration;BuildNumber=$(Format-BuildNumber $BuildNumber)"
     $opts += "/p:PackageOutputPath=$Artifacts"
+    
+    if (-not $Sign)
+    {
+        $opts += "/p:SignType=none"
+    }
     
     if ($PackageId) {
         $opts += "/p:PackageId=$PackageId"

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -194,6 +194,9 @@ Function Build-Solution {
     # Build the solution
     $opts = , $SolutionPath
     $opts += "/p:Configuration=$Configuration;BuildNumber=$(Format-BuildNumber $BuildNumber)"
+
+    # Build in parallel
+    # See https://docs.microsoft.com/en-us/visualstudio/msbuild/building-multiple-projects-in-parallel-with-msbuild?view=vs-2017#-maxcpucount-switch
     $opts += "/m"
     
     if ($TargetProfile) {

--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -19,7 +19,11 @@
   </ItemGroup>
   <Target Name="EnumerateFilesToSign" AfterTargets="AfterBuild" Condition="'$(SignAssembly)' == 'true' AND '$(SignType)' != 'none'">
     <ItemGroup>
-      <FilesToSign Include="$(TargetPath)">
+      <OutputToSign Include="$(MSBuildProjectDirectory)\%(IntermediateAssembly.Identity)" />
+      <OutputToSign Include="$(TargetPath)" />
+    </ItemGroup>
+    <ItemGroup>
+      <FilesToSign Include="%(OutputToSign.Identity)">
         <Authenticode>Microsoft</Authenticode>
         <StrongName>MsSharedLib72</StrongName>
       </FilesToSign>


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/1887

Now: 50 minutes
After: 7 minutes

How did I do it?
- Build and sign solution in parallel (`/m`)
- Turn off signing when packing (`/p:SignType:none`)
- Sign intermediate assemblies in `sign.microbuild.targets` (necessary because otherwise `New-ProjectPackage` will replace the signed output assemblies with the unsigned intermediate assemblies)

I expect we can get similar wins by doing this in our other repositories as well.

Additionally, I changed our `verbosity` from `minimal` back to the default. I did this because I think it will make it easier for us to debug build issues in the future.