### PR TITLE
Fix "displaySubComponents" of ActiveActiveComponent

### DIFF
--- a/src/NuGet.Services.Status/ActiveActiveComponent.cs
+++ b/src/NuGet.Services.Status/ActiveActiveComponent.cs
@@ -27,7 +27,7 @@ namespace NuGet.Services.Status
             string name,
             string description,
             IEnumerable<IComponent> subComponents)
-            : base(name, description, subComponents)
+            : base(name, description, subComponents, displaySubComponents: false)
         {
         }
 

--- a/src/NuGet.Services.Status/Component.cs
+++ b/src/NuGet.Services.Status/Component.cs
@@ -37,7 +37,7 @@ namespace NuGet.Services.Status
             string name,
             string description,
             IEnumerable<IComponent> subComponents,
-            bool displaySubComponents = true)
+            bool displaySubComponents)
             : this(name, description)
         {
             SubComponents = subComponents?.Select(s => new ComponentWrapper(s, this)).ToList()

--- a/src/NuGet.Services.Status/TreeComponent.cs
+++ b/src/NuGet.Services.Status/TreeComponent.cs
@@ -28,7 +28,7 @@ namespace NuGet.Services.Status
             string name,
             string description,
             IEnumerable<IComponent> subComponents)
-            : base(name, description, subComponents)
+            : base(name, description, subComponents, displaySubComponents: true)
         {
         }
 

--- a/tests/NuGet.Services.Status.Tests/ComponentWithSubComponentsTests.cs
+++ b/tests/NuGet.Services.Status.Tests/ComponentWithSubComponentsTests.cs
@@ -184,6 +184,43 @@ namespace NuGet.Services.Status.Tests
                 ancestorComponent, 
                 ancestorComponent.Path);
         }
+        
+        [Theory]
+        [ClassData(typeof(ComponentTestData.ComponentStatusPairs))]
+        public void SetsDisplaySubComponentsProperly(
+            ComponentStatus subStatus1,
+            ComponentStatus subStatus2)
+        {
+            var subComponent1 = CreateComponent("subComponent1", "subDescription1");
+            subComponent1.Status = subStatus1;
+
+            var subComponent2 = CreateComponent("subComponent2", "subDescription2");
+            subComponent2.Status = subStatus2;
+
+            var ancestorComponent = CreateComponent("root", "rootDescription", new[] { subComponent1, subComponent2 });
+
+            AssertDisplayComponentsSetProperly(ancestorComponent);
+        }
+
+        /// <summary>
+        /// <see cref="Component.DisplaySubComponents"/> should be set to false by a <see cref="Component"/> implementation if 
+        /// when one of its <see cref="Component.SubComponents"/> is not <see cref="Component.Up"/>, it MUST NOT return <see cref="ComponentStatus.Up"/>.
+        /// </summary>
+        /// <remarks>
+        /// The intention of <see cref="Component.DisplaySubComponents"/> is to hide components that are not impactful from being displayed to customers.
+        /// If a component determines status in such a way that it is not degraded when any of its subcomponents are degraded, it implies that its subcomponents are not impactful,
+        /// so it should set <see cref="Component.DisplaySubComponents"/> to false.
+        /// </remarks>
+        private void AssertDisplayComponentsSetProperly(IComponent ancestorComponent)
+        {
+            Assert.True(
+                // Either all subcomponents are up
+                ancestorComponent.SubComponents.All(c => c.Status == ComponentStatus.Up) ||
+                // Or the status is not up
+                ancestorComponent.Status != ComponentStatus.Up || 
+                // Or we are hiding subcomponents
+                !ancestorComponent.DisplaySubComponents);
+        }
 
         private void AssertLeastCommonAncestorPath(IComponent firstComponent, IComponent secondComponent, string expectedLeastCommonAncestor)
         {

--- a/tests/NuGet.Services.Status.Tests/ComponentWithSubComponentsTests.cs
+++ b/tests/NuGet.Services.Status.Tests/ComponentWithSubComponentsTests.cs
@@ -208,8 +208,8 @@ namespace NuGet.Services.Status.Tests
         /// </summary>
         /// <remarks>
         /// The intention of <see cref="Component.DisplaySubComponents"/> is to hide components that are not impactful from being displayed to customers.
-        /// If a component determines status in such a way that it is not degraded when any of its subcomponents are degraded, it implies that its subcomponents are not impactful,
-        /// so it should set <see cref="Component.DisplaySubComponents"/> to false.
+        /// If a component determines status in such a way that it is not degraded when any of its subcomponents are degraded, 
+        /// it implies that its subcomponents are not impactful, so it should set <see cref="Component.DisplaySubComponents"/> to false.
         /// </remarks>
         private void AssertDisplayComponentsSetProperly(IComponent ancestorComponent)
         {


### PR DESCRIPTION
Accidentally merged https://github.com/NuGet/ServerCommon/pull/186 without realizing that it needs to set `displaySubComponents` to `false` or else its subcomponents will appear on the status page (e.g. `Search Global USNC` and `Search Global USSC`).

To make sure this doesn't happen again, I also made it so that `displaySubComponents` must now be explicitly stated in each `Component` implementation. I also added a test that verifies that each `Component` implementation sets it properly.