### PR TITLE
Enable KeyVault injection into environment variables

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationBuilderExtensions.cs
@@ -9,11 +9,26 @@ namespace NuGet.Services.Configuration
 {
     public static class ConfigurationBuilderExtensions
     {
-        public static IConfigurationBuilder AddInjectedJsonFile(this IConfigurationBuilder configurationBuilder, string path, ISecretInjector secretInjector)
+        public static IConfigurationBuilder AddInjectedJsonFile(
+            this IConfigurationBuilder configurationBuilder,
+            string path,
+            ISecretInjector secretInjector)
         {
             configurationBuilder = configurationBuilder ?? throw new ArgumentNullException(nameof(configurationBuilder));
 
             configurationBuilder.Add(new KeyVaultJsonInjectingConfigurationSource(path, secretInjector));
+
+            return configurationBuilder;
+        }
+
+        public static IConfigurationBuilder AddInjectedEnvironmentVariables(
+            this IConfigurationBuilder configurationBuilder,
+            string prefix,
+            ISecretInjector secretInjector)
+        {
+            configurationBuilder = configurationBuilder ?? throw new ArgumentNullException(nameof(configurationBuilder));
+
+            configurationBuilder.Add(new KeyVaultEnvironmentVariableInjectingConfigurationSource(prefix, secretInjector));
 
             return configurationBuilder;
         }

--- a/src/NuGet.Services.Configuration/KeyVaultEnvironmentVariableInjectingConfigurationSource.cs
+++ b/src/NuGet.Services.Configuration/KeyVaultEnvironmentVariableInjectingConfigurationSource.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using NuGet.Services.KeyVault;
+
+namespace NuGet.Services.Configuration
+{
+    public class KeyVaultEnvironmentVariableInjectingConfigurationSource : IConfigurationSource
+    {
+        private readonly string _prefix;
+        private readonly ISecretInjector _secretInjector;
+
+        public KeyVaultEnvironmentVariableInjectingConfigurationSource(string prefix, ISecretInjector secretInjector)
+        {
+            _prefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
+            _secretInjector = secretInjector ?? throw new ArgumentNullException(nameof(secretInjector));
+        }
+
+        public Microsoft.Extensions.Configuration.IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            var envSource = new EnvironmentVariablesConfigurationSource
+            {
+                Prefix = _prefix,
+            };
+            var envProvider = envSource.Build(builder);
+
+            return new KeyVaultInjectingConfigurationProvider(envProvider, _secretInjector);
+        }
+    }
+}

--- a/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
+++ b/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
@@ -62,6 +62,7 @@
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="IConfigurationFactory.cs" />
     <Compile Include="IConfigurationProvider.cs" />
+    <Compile Include="KeyVaultEnvironmentVariableInjectingConfigurationSource.cs" />
     <Compile Include="KeyVaultInjectingConfigurationProvider.cs" />
     <Compile Include="KeyVaultJsonInjectingConfigurationSource.cs" />
     <Compile Include="NonCachingOptionsSnapshot.cs" />
@@ -78,6 +79,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions">
       <Version>1.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables">
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions">
       <Version>1.1.2</Version>

--- a/tests/NuGet.Services.Configuration.Tests/ConfigurationBuilderExtensionsFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/ConfigurationBuilderExtensionsFacts.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NuGet.Services.KeyVault;
+using Xunit;
+
+namespace NuGet.Services.Configuration.Tests
+{
+    public class ConfigurationBuilderExtensionsFacts
+    {
+        public class AddInjectedEnvironmentVariables
+        {
+            [Fact]
+            public void InjectsSecretsIntoEnvironmentVariables()
+            {
+                Environment.SetEnvironmentVariable("NUGET_TEST_MySecret", "My secret is $$hidden$$.");
+                var secretInjector = new Mock<ISecretInjector>();
+                secretInjector
+                    .Setup(x => x.InjectAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => "My secret is visible.");
+                var configuration = new ConfigurationBuilder()
+                    .AddInjectedEnvironmentVariables("NUGET_TEST_", secretInjector.Object)
+                    .Build();
+
+                var value = configuration.GetValue<string>("MySecret");
+
+                Assert.Equal("My secret is visible.", value);
+                secretInjector.Verify(x => x.InjectAsync("My secret is $$hidden$$."), Times.Once);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Configuration.Tests/NuGet.Services.Configuration.Tests.csproj
+++ b/tests/NuGet.Services.Configuration.Tests/NuGet.Services.Configuration.Tests.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationAttributeFacts.cs" />
+    <Compile Include="ConfigurationBuilderExtensionsFacts.cs" />
     <Compile Include="ConfigurationFactoryFacts.cs" />
     <Compile Include="ConfigurationProviderFacts.cs" />
     <Compile Include="ConfigurationUtilityFacts.cs" />


### PR DESCRIPTION
This will enable configuration for Web Apps.

This is the ARM resource that sets configuration on an Azure slot.
```json
{
    "apiVersion": "2018-02-01",
    "name": "appsettings",
    "type": "config",
    "dependsOn": [
        "[resourceId('Microsoft.Web/sites/slots', parameters('websiteName'), variables('slotName'))]"
    ],
    "properties": "[parameters('appSettings')]"
}
```

This is a trimmed example of the parameters file:
```json
{
    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
    "contentVersion": "1.0.0.0",
    "parameters": {
        "appSettings": {
            "value": {
                "SearchService:SearchServiceName": "jver-search"
            }
        }
    }
}
```

The environment variables come out like this at runtime.

**Key**: `APPSETTING_SearchService:SearchServiceName`
**Value**: `jver-search`

The benefit of this approach over pure JSON configuration on disk (like jobs) is that we can modify app settings from the portal.

![image](https://user-images.githubusercontent.com/94054/50864855-2c223580-1358-11e9-97c1-dead6c5c8cd3.png)


