### PR TITLE
Exception logging for exceptions leaked to ServiceBus SDK.

### DIFF
--- a/src/NuGet.Services.ServiceBus/OnMessageOptionsWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/OnMessageOptionsWrapper.cs
@@ -8,23 +8,29 @@ namespace NuGet.Services.ServiceBus
 {
     public sealed class OnMessageOptionsWrapper : IOnMessageOptions
     {
-        public OnMessageOptions OnMessageOptions { get; set; }
+        /// <summary>
+        /// Specifies whether the Service Bus message completes when message callback returns.
+        /// </summary>
+        /// <remarks>
+        /// Default value is set to the default value of the respective property of <see cref="OnMessageOptions"/>.
+        /// </remarks>
+        public bool AutoComplete { get; set; } = true;
 
-        public bool AutoComplete
-        {
-            get => OnMessageOptions.AutoComplete;
-            set => OnMessageOptions.AutoComplete = value;
-        }
+        /// <summary>
+        /// Specifies the maximum number of concurrent message callbacks.
+        /// </summary>
+        /// <remarks>
+        /// Default value is set to the default value of the respective property of <see cref="OnMessageOptions"/>.
+        /// </remarks>
+        public int MaxConcurrentCalls { get; set; } = 1;
 
-        public int MaxConcurrentCalls
+        public OnMessageOptions GetOptions()
         {
-            get => OnMessageOptions.MaxConcurrentCalls;
-            set => OnMessageOptions.MaxConcurrentCalls = value;
-        }
-
-        public OnMessageOptionsWrapper(OnMessageOptions options = null)
-        {
-            OnMessageOptions = OnMessageOptions ?? new OnMessageOptions();
+            return new OnMessageOptions
+            {
+                AutoComplete = AutoComplete,
+                MaxConcurrentCalls = MaxConcurrentCalls,
+            };
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1931

Had to change `OnMessageOptionsWrapper` to not keep the instance of `OnMessageOptions` but produce one on demand so that the lifetime of that object can be controlled by the caller. The reason to do it was that `SubscriptionClientWrapper` now adds an event to the instance of `OnMessageOptions`, so any additional references to `OnMessageOptions` would extend the life time of `SubscriptionClientWrapper`, which is likely not desired.

With the current code it is guaranteed that `SubscriptionClientWrapper` will be the sole owner of the `OnMessageOptions` and no lifetime extension would happen.