### PR TITLE
Add recursive to common.ps1 submodules cmdlets

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -332,8 +332,7 @@ Function Update-Submodule {
         [string] $Name,
         [string] $Path,
         [string] $Branch,
-        [string] $RemoteUrl,
-        [switch] $Recursive
+        [string] $RemoteUrl
     )
 
     Trace-Log "Configuring submodule $Name ($Path) to use branch $Branch."
@@ -354,10 +353,7 @@ Function Update-Submodule {
     }
 
     Trace-Log "Updating submodule $Name ($Path)."
-    $args = 'submodule', 'update', '--init', '--remote', '--', "$Path"
-    if ($Recursive) {
-        $args += '--recursive'
-    }
+    $args = 'submodule', 'update', '--init', '--remote', '--', "$Path", '--recursive'
     
     if (-not $VerbosePreference) {
         $args += '--quiet'

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -321,7 +321,7 @@ Function Invoke-Git {
 
 Function Reset-Submodules {
     Trace-Log 'Resetting submodules'
-    $args = 'submodule', 'foreach', 'git', 'reset', '--hard'
+    $args = 'submodule', 'foreach', '--recursive', 'git', 'reset', '--hard'
 
     Invoke-Git -Arguments $args
 }
@@ -332,7 +332,8 @@ Function Update-Submodule {
         [string] $Name,
         [string] $Path,
         [string] $Branch,
-        [string] $RemoteUrl
+        [string] $RemoteUrl,
+        [switch] $Recursive
     )
 
     Trace-Log "Configuring submodule $Name ($Path) to use branch $Branch."
@@ -354,6 +355,10 @@ Function Update-Submodule {
 
     Trace-Log "Updating submodule $Name ($Path)."
     $args = 'submodule', 'update', '--init', '--remote', '--', "$Path"
+    if ($Recursive) {
+        $args += '--recursive'
+    }
+    
     if (-not $VerbosePreference) {
         $args += '--quiet'
     }


### PR DESCRIPTION
This is needed for https://github.com/nuget/engineering/issues/2249 because `NuGet.Status` has a `NuGetGallery` submodule which becomes a nested submodule when `NuGet.Status` is a submodule inside `NuGetDeployment`.