### PR TITLE
Add sign.proj which runs package signing on all artifacts nupkgs

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -173,6 +173,18 @@ Function Invoke-BuildStep {
     }
 }
 
+Function Sign-Packages {
+    [CmdletBinding()]
+    param(
+        [string]$Configuration = $DefaultConfiguration,
+        [int]$BuildNumber = (Get-BuildNumber),
+        [string]$MSBuildVersion = $DefaultMSBuildVersion
+    )
+
+    $ProjectPath = Join-Path $PSScriptRoot "sign.proj"
+    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $ProjectPath
+}
+
 Function Build-Solution {
     [CmdletBinding()]
     param(

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="AfterBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props" Condition="Exists('..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.props')" />
+
+  <PropertyGroup>
+    <RepositoryRootDirectory>$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))\</RepositoryRootDirectory>
+    <IntermediateOutputPath>$(RepositoryRootDirectory)artifacts\sign\obj\</IntermediateOutputPath>
+    <OutDir>$(RepositoryRootDirectory)</OutDir>
+    <SignTargetsDependOn>GetOutputNupkgs</SignTargetsDependOn>
+  </PropertyGroup>
+
+  <Target Name="GetOutputNupkgs">
+    <ItemGroup>
+      <FilesToSign Include="$(RepositoryRootDirectory)artifacts\*.nupkg">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Text="Files to sign:%0A@(FilesToSign, '%0A')" Importance="High" />
+  </Target>
+
+  <Target Name="AfterBuild" DependsOnTargets="$(SignTargetsDependOn)"/>
+
+  <Import Project="..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets" Condition="Exists('..\packages\MicroBuild.Core.0.3.0\build\MicroBuild.Core.targets')" />
+</Project>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2242
Progress on https://github.com/NuGet/Engineering/issues/2243
Progress on https://github.com/NuGet/Engineering/issues/2244

You can just do `Sign-Packages` and it will sign all .nupkgs in artifacts directory. This already works in NuGet.Server.