### PR TITLE
Explicitly require Newtonsoft.Json dependency to be minimum v9.0.1

### DIFF
--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -87,6 +87,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>1.0.0</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>9.0.1</Version>
+    </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>
     </PackageReference>

--- a/tests/NuGet.Services.Storage.Tests/NuGet.Services.Storage.Tests.csproj
+++ b/tests/NuGet.Services.Storage.Tests/NuGet.Services.Storage.Tests.csproj
@@ -47,6 +47,9 @@
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>9.0.1</Version>
+    </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>
     </PackageReference>


### PR DESCRIPTION
For `NuGet.Services.Storage`