### PR TITLE
Submodule fixes for NuGet.Services.Status build

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -333,7 +333,7 @@ Function Invoke-Git {
 
 Function Reset-Submodules {
     Trace-Log 'Resetting submodules'
-    $args = 'submodule', 'foreach', '--recursive', 'git', 'reset', '--hard'
+    $args = 'submodule', 'foreach', 'git', 'reset', '--hard'
 
     Invoke-Git -Arguments $args
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -333,7 +333,7 @@ Function Invoke-Git {
 
 Function Reset-Submodules {
     Trace-Log 'Resetting submodules'
-    $args = 'submodule', 'foreach', 'git', 'reset', '--hard'
+    $args = 'submodule', 'deinit', '--all', '-f'
 
     Invoke-Git -Arguments $args
 }
@@ -365,7 +365,7 @@ Function Update-Submodule {
     }
 
     Trace-Log "Updating submodule $Name ($Path)."
-    $args = 'submodule', 'update', '--init', '--remote', '--', "$Path"
+    $args = 'submodule', 'update', '--init', '--remote', '--recursive', '--', "$Path"
     
     if (-not $VerbosePreference) {
         $args += '--quiet'

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -311,11 +311,7 @@ Function Invoke-FxCop {
     }
     
     # Invoke using the msbuild RunCodeAnalysis target
-    $msBuildProps = "/p:CustomBeforeMicrosoftCSharpTargets=$codeAnalysisProps;SignType=none"
-    
-    if ($VerbosePreference) {
-        $msBuildProps += ";CodeAnalysisVerbose=true"
-    }
+    $msBuildProps = "/p:CustomBeforeMicrosoftCSharpTargets=$codeAnalysisProps;SignType=none;CodeAnalysisVerbose=true"
     
     Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $SolutionPath -Target "Rebuild;RunCodeAnalysis" -MSBuildProperties $msBuildProps -SkipRestore:$SkipRestore
 }
@@ -366,10 +362,6 @@ Function Update-Submodule {
 
     Trace-Log "Updating submodule $Name ($Path)."
     $args = 'submodule', 'update', '--init', '--remote', '--', "$Path"
-    
-    if (-not $VerbosePreference) {
-        $args += '--quiet'
-    }
 
     Invoke-Git -Arguments $args
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -365,7 +365,7 @@ Function Update-Submodule {
     }
 
     Trace-Log "Updating submodule $Name ($Path)."
-    $args = 'submodule', 'update', '--init', '--remote', '--recursive', '--', "$Path"
+    $args = 'submodule', 'update', '--init', '--remote', '--', "$Path"
     
     if (-not $VerbosePreference) {
         $args += '--quiet'


### PR DESCRIPTION
- use `deinit` instead of `foreach --recursive git reset --hard` because it is the proper way to deinitialize submodules
- remove `--recursive` in `Update-Submodule`
    - `--recursive` causes the build to update all nested submodules with their latest `master`, but this is not what we want for `NuGet.Services.Status` because its `NuGetGallery` submodule is intended to remain on a specific commit until it is updated
    - I have modified `NuGet.Services.Status`'s build script to manually update the `NuGetGallery` submodule with the commit in the repository (`git submodule update --init -- <path>`)
    - This should not affect any builds, because `NuGet.Services.Status` is our only repository with nested submodules, and the only build updated to a version of ServerCommon with it is `NuGet.Licenses`
- removed all verbosity preferences because they are annoying to deal with when debugging issues on a build machine