### PR TITLE
[Feature Flags] Handle nulls as anonymous users

### DIFF
--- a/src/NuGet.Services.FeatureFlags/FeatureFlagClient.cs
+++ b/src/NuGet.Services.FeatureFlags/FeatureFlagClient.cs
@@ -84,19 +84,23 @@ namespace NuGet.Services.FeatureFlags
                 return true;
             }
 
-            if (flight.Accounts.Contains(user.Username, StringComparer.OrdinalIgnoreCase))
+            // The user object may be null if the user is anonymous.
+            if (user != null)
             {
-                return true;
-            }
+                if (flight.Accounts.Contains(user.Username, StringComparer.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
 
-            if (TryParseEmailDomain(user.EmailAddress, out var domain) && flight.Domains.Contains(domain, StringComparer.OrdinalIgnoreCase))
-            {
-                return true;
-            }
+                if (TryParseEmailDomain(user.EmailAddress, out var domain) && flight.Domains.Contains(domain, StringComparer.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
 
-            if (flight.SiteAdmins && user.IsSiteAdmin)
-            {
-                return true;
+                if (flight.SiteAdmins && user.IsSiteAdmin)
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/NuGet.Services.FeatureFlags/IFeatureFlagClient.cs
+++ b/src/NuGet.Services.FeatureFlags/IFeatureFlagClient.cs
@@ -16,6 +16,10 @@ namespace NuGet.Services.FeatureFlags
         /// <summary>
         /// Get whether a flight is enabled for a user. This method does not throw.
         /// </summary>
+        /// <remarks>
+        /// Enabling a flight for all users will include anonymous users. If the flight should never be
+        /// enabled for logged out users, perform an "is logged in" check before calling this API.
+        /// </remarks>
         /// <param name="flight">The unique identifier for this flight. This is case insensitive.</param>
         /// <param name="user">The user whose status should be determined, or null if the user is anonymous.</param>
         /// <param name="defaultValue">The value to return if the status of the flight is unknown.</param>

--- a/src/NuGet.Services.FeatureFlags/IFeatureFlagClient.cs
+++ b/src/NuGet.Services.FeatureFlags/IFeatureFlagClient.cs
@@ -17,7 +17,7 @@ namespace NuGet.Services.FeatureFlags
         /// Get whether a flight is enabled for a user. This method does not throw.
         /// </summary>
         /// <param name="flight">The unique identifier for this flight. This is case insensitive.</param>
-        /// <param name="user">The user whose status should be determined.</param>
+        /// <param name="user">The user whose status should be determined, or null if the user is anonymous.</param>
         /// <param name="defaultValue">The value to return if the status of the flight is unknown.</param>
         /// <returns>Whether the flight is enabled for this user.</returns>
         bool IsEnabled(string flight, IFlightUser user, bool defaultValue);

--- a/tests/NuGet.Services.FeatureFlags.Tests/FeatureFlagClientFlightFacts.cs
+++ b/tests/NuGet.Services.FeatureFlags.Tests/FeatureFlagClientFlightFacts.cs
@@ -25,6 +25,7 @@ namespace NuGet.Services.FeatureFlags.Tests
                     .Returns<FeatureFlags>(null);
 
                 Assert.Equal(defaultValue, _target.IsEnabled("Flight", _user, defaultValue));
+                Assert.Equal(defaultValue, _target.IsEnabled("Flight", _anonymous, defaultValue));
             }
 
             [Theory]
@@ -42,6 +43,7 @@ namespace NuGet.Services.FeatureFlags.Tests
                     .Returns(latestFlags);
 
                 Assert.Equal(defaultValue, _target.IsEnabled("Unknown", _user, defaultValue));
+                Assert.Equal(defaultValue, _target.IsEnabled("Unknown", _anonymous, defaultValue));
             }
 
             [Theory]
@@ -63,6 +65,9 @@ namespace NuGet.Services.FeatureFlags.Tests
 
                 Assert.False(_target.IsEnabled("Flight", _admin, defaultValue));
                 Assert.False(_target.IsEnabled("flight", _admin, defaultValue));
+
+                Assert.False(_target.IsEnabled("Flight", _anonymous, defaultValue));
+                Assert.False(_target.IsEnabled("flight", _anonymous, defaultValue));
             }
 
             [Theory]
@@ -84,6 +89,9 @@ namespace NuGet.Services.FeatureFlags.Tests
 
                 Assert.True(_target.IsEnabled("Flight", _admin, defaultValue));
                 Assert.True(_target.IsEnabled("flight", _admin, defaultValue));
+
+                Assert.True(_target.IsEnabled("Flight", _anonymous, defaultValue));
+                Assert.True(_target.IsEnabled("flight", _anonymous, defaultValue));
             }
 
             [Theory]
@@ -105,6 +113,9 @@ namespace NuGet.Services.FeatureFlags.Tests
 
                 Assert.True(_target.IsEnabled("Flight", _admin, defaultValue));
                 Assert.True(_target.IsEnabled("flight", _admin, defaultValue));
+
+                Assert.False(_target.IsEnabled("Flight", _anonymous, defaultValue));
+                Assert.False(_target.IsEnabled("flight", _anonymous, defaultValue));
 
                 // Account names should be case insensitive
                 var user2 = new TestFlightUser { Username = "CASE_TEST", EmailAddress = "test@nuget.org" };
@@ -133,6 +144,9 @@ namespace NuGet.Services.FeatureFlags.Tests
                 Assert.False(_target.IsEnabled("Flight", _user, defaultValue));
                 Assert.False(_target.IsEnabled("flight", _user, defaultValue));
 
+                Assert.False(_target.IsEnabled("Flight", _anonymous, defaultValue));
+                Assert.False(_target.IsEnabled("flight", _anonymous, defaultValue));
+
                 // Domains should be case insensitive
                 var user2 = new TestFlightUser { Username = "case_test", EmailAddress = "TEST@NUGET.ORG" };
 
@@ -159,6 +173,9 @@ namespace NuGet.Services.FeatureFlags.Tests
 
                 Assert.True(_target.IsEnabled("flight", _admin, defaultValue));
                 Assert.True(_target.IsEnabled("Flight", _admin, defaultValue));
+
+                Assert.False(_target.IsEnabled("Flight", _anonymous, defaultValue));
+                Assert.False(_target.IsEnabled("flight", _anonymous, defaultValue));
             }
         }
 
@@ -169,6 +186,7 @@ namespace NuGet.Services.FeatureFlags.Tests
 
             protected readonly IFlightUser _user;
             protected readonly IFlightUser _admin;
+            protected readonly IFlightUser _anonymous;
 
             public FactsBase()
             {
@@ -191,6 +209,8 @@ namespace NuGet.Services.FeatureFlags.Tests
                     EmailAddress = "admin@nuget.org",
                     IsSiteAdmin = true,
                 };
+
+                _anonymous = null;
             }
 
             protected class TestFlightUser : IFlightUser


### PR DESCRIPTION
The gallery signifies a user that's not logged in as a `null` value, which wasn't handled properly.

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2530168