### PR TITLE
[SQL AAD] Reduce Gallery's logging by ~25%

### DIFF
--- a/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
@@ -95,11 +95,6 @@ namespace NuGet.Services.Sql
         {
             var authResult = await AccessTokenCache.GetAsync(ConnectionString, clientCertificateData, Logger);
 
-            Logger?.LogInformation("Using access token {Token} for catalog {Catalog} which expires in {ExpirationMinutes}m.",
-                authResult.AccessToken.GetHashCode(),
-                ConnectionString.Sql.InitialCatalog,
-                (authResult.ExpiresOn - DateTimeOffset.Now).TotalMinutes.ToString("F2"));
-
             return authResult.AccessToken;
         }
     }


### PR DESCRIPTION
The SQL connection factory emits a log of how long until the SQL AAD token expires each time it does a SQL query. This accounts for ~25% of the Gallery's logs (as many as 40M logs per day). I've removed this log as it adds little value.

Part of https://github.com/NuGet/NuGetGallery/issues/7025