### PR TITLE
Attempting to fix building everything when VS 2019 is the only one installed

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -107,9 +107,11 @@ Function Get-MSBuildExe {
         }
         
         $installations = @([NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
-            $MSBuildRoot = Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
-            Join-Path $MSBuildRoot $MSBuildExeRelPath
-        } | Where-Object { Test-Path $_ })
+            Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
+            Join-Path $_ "MSBuild\Current"
+        } | ForEach-Object {
+            Join-Path $_ $MSBuildExeRelPath
+        } | Where-Object { Test-Path $_ } | Where-Object { (Get-Item $_).VersionInfo.ProductMajorPart -eq $MSBuildVersion })
         
         if ($installations.Count -ge 1) {
             $MSBuildPath = $installations[0]

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -77,51 +77,17 @@ Function Clear-Artifacts {
     }
 }
 
-Function Get-MSBuildExeInternal([int]$MSBuildVersion)
-{
-    if ($MSBuildVersion -lt 15) {
-        $MSBuildExe = Join-Path $MSBuildRoot ([string]$MSBuildVersion + ".0")
-        $MSBuildPath = Join-Path $MSBuildExe $MSBuildExeRelPath
-        return $MSBuildPath;
-    } elseif ($MSBuildVersion -eq 16) {
-        $pathsToCheck = @(
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe",
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe",
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe",
-            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe");
-
-        foreach ($msbuildPathCandidate in $pathsToCheck)
-        {
-            if (Test-Path -Path $msbuildPathCandidate -PathType Leaf)
-            {
-                $version = (Get-Item $msbuildPathCandidate).VersionInfo;
-                if ($version.ProductMajorPart -eq $MSBuildVersion)
-                {
-                    return $msbuildPathCandidate;
-                }
-            }
-        }
-    }
-
-    # checking if by chance proper msbuild is in PATH
-    $command = Get-Command msbuild -ErrorAction Ignore
-    if ($command -ne $null -and $command.Version.Major -eq $MSBuildVersion)
-    {
-        return $command.Path
-    }
-
-    return $null;
-}
-
 Function Get-MSBuildExe {
     param(
         [int]$MSBuildVersion
     )
     
-    $MSBuildPath = Get-MSBuildExeInternal -MSBuildVersion $MSBuildVersion
+    $MSBuildPath = $null
 
-    if ($MSBuildPath -eq $null) {
+    if ($MSBuildVersion -lt 15) {
+        $MSBuildExe = Join-Path $MSBuildRoot ([string]$MSBuildVersion + ".0")
+        $MSBuildPath = Join-Path $MSBuildExe $MSBuildExeRelPath
+    } else {
         # Check if VS package to use to find $NuGetBuildPackageId is installed. If not, install it.
         $buildPackageFound = [System.AppDomain]::CurrentDomain.GetAssemblies() | `
             Where-Object { $_.FullName -like "$($NuGetBuildPackageId), *" }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -1,5 +1,5 @@
 ### Constants ###
-$DefaultMSBuildVersion = '15'
+$DefaultMSBuildVersion = '16'
 $DefaultConfiguration = 'debug'
 $NuGetClientRoot = Split-Path -Path $PSScriptRoot -Parent
 $CLIRoot = Join-Path $NuGetClientRoot 'cli'
@@ -107,8 +107,8 @@ Function Get-MSBuildExe {
         }
         
         $installations = @([NuGet.Services.Build.VisualStudioSetupConfigurationHelper]::GetInstancePaths() | ForEach-Object {
-            Join-Path "$_\MSBuild" ([string]$MSBuildVersion + ".0")
-            Join-Path $_ "MSBuild\Current"
+            [System.IO.Path]::Combine($_, "MSBuild", [string]$MSBuildVersion + ".0")
+            [System.IO.Path]::Combine($_, "MSBuild", "Current")
         } | ForEach-Object {
             Join-Path $_ $MSBuildExeRelPath
         } | Where-Object { Test-Path $_ } | Where-Object { (Get-Item $_).VersionInfo.ProductMajorPart -eq $MSBuildVersion })


### PR DESCRIPTION
Extracted part of the logic of `Get-MsBuildExe` function into `Get-MsBuildExeInternal` so I could try a bunch of things and `return` as soon as we find something. Adjusted the fallback in the original function accordingly.