### PR TITLE
Add RefreshableSecretReader to allow background thread secret refresh

### DIFF
--- a/src/NuGet.Services.KeyVault/EmptySecretReader.cs
+++ b/src/NuGet.Services.KeyVault/EmptySecretReader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault

--- a/src/NuGet.Services.KeyVault/IRefreshableSecretReaderFactory.cs
+++ b/src/NuGet.Services.KeyVault/IRefreshableSecretReaderFactory.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    /// <summary>
+    /// An interface that allows caching and refreshing the secrets fetched by secret readers.
+    /// </summary>
+    public interface IRefreshableSecretReaderFactory : ISecretReaderFactory
+    {
+        /// <summary>
+        /// Refresh the values of the secrets that have already been read and cached. Since the cache is shared between
+        /// all <see cref="ISecretReader"/> instances creates, this refresh applies to all secret readers created by
+        /// this factory.
+        /// </summary>
+        /// <param name="token">A cancellation token.</param>
+        Task RefreshAsync(CancellationToken token);
+    }
+}

--- a/src/NuGet.Services.KeyVault/ISecret.cs
+++ b/src/NuGet.Services.KeyVault/ISecret.cs
@@ -2,10 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault
 {

--- a/src/NuGet.Services.KeyVault/ISecretReader.cs
+++ b/src/NuGet.Services.KeyVault/ISecretReader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault

--- a/src/NuGet.Services.KeyVault/KeyVaultSecret.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultSecret.cs
@@ -2,10 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault
 {

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CachingSecretReader.cs" />
     <Compile Include="CachingSecretReaderFactory.cs" />
     <Compile Include="CertificateUtility.cs" />
+    <Compile Include="IRefreshableSecretReaderFactory.cs" />
     <Compile Include="ISecret.cs" />
     <Compile Include="ISecretReaderFactory.cs" />
     <Compile Include="EmptySecretReader.cs" />
@@ -61,6 +62,9 @@
     <Compile Include="KeyVaultConfiguration.cs" />
     <Compile Include="KeyVaultReader.cs" />
     <Compile Include="KeyVaultSecret.cs" />
+    <Compile Include="RefreshableSecretReader.cs" />
+    <Compile Include="RefreshableSecretReaderFactory.cs" />
+    <Compile Include="RefreshableSecretReaderSettings.cs" />
     <Compile Include="SecretInjector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReader.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    /// <summary>
+    /// A secret reader that separates the refreshing of secret values from the reading of them from an in-memory
+    /// cache. Although the <see cref="GetSecretAsync(string)"/> and <see cref="GetSecretObjectAsync(string)"/> methods
+    /// are asynchronous in definition they do not result an any asynchronous operations when a secret has already been
+    /// cached with a previous invocation. The <see cref="RefreshAsync"/> method is used to refresh the values of
+    /// secrets that have already been cached.
+    /// </summary>
+    public class RefreshableSecretReader : ISecretReader
+    {
+        private readonly ISecretReader _secretReader;
+        private readonly ConcurrentDictionary<string, ISecret> _cache;
+        private readonly RefreshableSecretReaderSettings _settings;
+
+        public RefreshableSecretReader(
+            ISecretReader secretReader,
+            ConcurrentDictionary<string, ISecret> cache,
+            RefreshableSecretReaderSettings settings)
+        {
+            _secretReader = secretReader ?? throw new ArgumentNullException(nameof(secretReader));
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public async Task RefreshAsync(CancellationToken token)
+        {
+            foreach (var secretName in _cache.Keys)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                await UncachedGetSecretObjectAsync(secretName);
+            }
+        }
+
+        public Task<string> GetSecretAsync(string secretName)
+        {
+            if (TryGetCachedSecretObject(secretName, out var secret))
+            {
+                return Task.FromResult(secret.Value);
+            }
+
+            return UncachedGetSecretAsync(secretName);
+        }
+
+        public Task<ISecret> GetSecretObjectAsync(string secretName)
+        {
+            if (TryGetCachedSecretObject(secretName, out var secret))
+            {
+                return Task.FromResult(secret);
+            }
+
+            return UncachedGetSecretObjectAsync(secretName);
+        }
+
+        private async Task<string> UncachedGetSecretAsync(string secretName)
+        {
+            var secretObject = await UncachedGetSecretObjectAsync(secretName);
+            return secretObject.Value;
+        }
+
+        private async Task<ISecret> UncachedGetSecretObjectAsync(string secretName)
+        {
+            var secretObject = await _secretReader.GetSecretObjectAsync(secretName);
+            _cache.AddOrUpdate(secretName, secretObject, (_, __) => secretObject);
+            return secretObject;
+        }
+
+        private bool TryGetCachedSecretObject(string secretName, out ISecret secret)
+        {
+            if (_cache.TryGetValue(secretName, out secret))
+            {
+                return true;
+            }
+
+            if (_settings.BlockUncachedReads)
+            {
+                throw new InvalidOperationException($"The secret '{secretName}' is not cached.");
+            }
+
+            secret = null;
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    /// <summary>
+    /// Wraps existing secret reader factory to provide a caching layer where the cache refresh is controlled by
+    /// the <see cref="RefreshAsync"/> method on the factory created <see cref="ISecretReader"/> instances.
+    /// </summary>
+    public class RefreshableSecretReaderFactory : IRefreshableSecretReaderFactory
+    {
+        private readonly ISecretReaderFactory _underlyingFactory;
+        private readonly ConcurrentDictionary<string, ISecret> _cache;
+        private readonly RefreshableSecretReaderSettings _settings;
+
+        public RefreshableSecretReaderFactory(ISecretReaderFactory underlyingFactory, RefreshableSecretReaderSettings settings)
+        {
+            _underlyingFactory = underlyingFactory ?? throw new ArgumentNullException(nameof(underlyingFactory));
+            _cache = new ConcurrentDictionary<string, ISecret>();
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public async Task RefreshAsync(CancellationToken token)
+        {
+            await GetRefreshableSecretReader().RefreshAsync(token);
+        }
+
+        public ISecretInjector CreateSecretInjector(ISecretReader secretReader)
+        {
+            return _underlyingFactory.CreateSecretInjector(secretReader);
+        }
+
+        public ISecretReader CreateSecretReader()
+        {
+            return GetRefreshableSecretReader();
+        }
+
+        private RefreshableSecretReader GetRefreshableSecretReader()
+        {
+            var innerSecretReader = _underlyingFactory.CreateSecretReader();
+            return new RefreshableSecretReader(innerSecretReader, _cache, _settings);
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReaderSettings.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReaderSettings.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+
+namespace NuGet.Services.KeyVault
+{
+    /// <summary>
+    /// The purpose of this class is to allow a <see cref="RefreshableSecretReaderFactory"/> to dynamically control the
+    /// settings of the <see cref="RefreshableSecretReader"/> instance that it creates. This does not follow the 
+    /// Microsoft.Extensions.Options (e.g. IOptionsSnapshot, IOptions) pattern because this is meant to initialized and
+    /// modified at runtime.
+    /// </summary>
+    public class RefreshableSecretReaderSettings
+    {
+        /// <summary>
+        /// Prevent <see cref="RefreshableSecretReader.GetSecretAsync(string)"/> or
+        /// <see cref="RefreshableSecretReader.GetSecretObjectAsync(string)"/> from getting secrets from the underlying
+        /// secret reader. If one of these methods is executed and the provided secret is not found, an
+        /// <see cref="InvalidOperationException"/> will be thrown. In a web application, this should be enabled during
+        /// startup so that requests encounter an exception instead of reading a secret from KeyVault in a context that
+        /// may cause a deadlock. It's better to throw an exception than deadlock.
+        /// </summary>
+        public bool BlockUncachedReads { get; set; }
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
+++ b/tests/NuGet.Services.KeyVault.Tests/NuGet.Services.KeyVault.Tests.csproj
@@ -41,6 +41,8 @@
     <Compile Include="CachingSecretReaderFacts.cs" />
     <Compile Include="KeyVaultReaderFormatterFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RefreshableSecretReaderFactoryFacts.cs" />
+    <Compile Include="RefreshableSecretReaderFacts.cs" />
     <Compile Include="SecretReaderFacts.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.KeyVault.Tests/RefreshableSecretReaderFactoryFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/RefreshableSecretReaderFactoryFacts.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class RefreshableSecretReaderFactoryFacts
+    {
+        public class CreateSecretReader : Facts
+        {
+            [Fact]
+            public async Task CreatesWrapper()
+            {
+                var actual = Target.CreateSecretReader();
+
+                var secret = await actual.GetSecretObjectAsync(SecretName);
+                Assert.IsType<RefreshableSecretReader>(actual);
+                Assert.Same(secret, Secret.Object);
+                UnderlyingReader.Verify(x => x.GetSecretObjectAsync(SecretName), Times.Once);
+            }
+        }
+
+        public class CreateSecretInjector : Facts
+        {
+            [Fact]
+            public void CreatesWrapper()
+            {
+                var actual = Target.CreateSecretInjector(UnderlyingReader.Object);
+
+                UnderlyingFactory.Verify(
+                    x => x.CreateSecretInjector(UnderlyingReader.Object),
+                    Times.Once);
+            }
+        }
+
+        public class RefreshAsync : Facts
+        {
+            [Fact]
+            public async Task RefreshesSecrets()
+            {
+                var reader = Target.CreateSecretReader();
+                await reader.GetSecretAsync(SecretName);
+                UnderlyingReader.Invocations.Clear();
+
+                await Target.RefreshAsync(CancellationToken.None);
+
+                UnderlyingReader.Verify(x => x.GetSecretObjectAsync(SecretName), Times.Once);
+            }
+        }
+
+        public class Settings : Facts
+        {
+            [Fact]
+            public async Task AffectCreatedReaders()
+            {
+                var actual = Target.CreateSecretReader();
+                Settings.BlockUncachedReads = true;
+
+                await Assert.ThrowsAsync<InvalidOperationException>(() => actual.GetSecretAsync(SecretName));
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts()
+            {
+                UnderlyingFactory = new Mock<ISecretReaderFactory>();
+                Settings = new RefreshableSecretReaderSettings();
+
+                SecretName = "secret";
+                UnderlyingReader = new Mock<ISecretReader>();
+                SecretInjector = new Mock<ISecretInjector>();
+                Secret = new Mock<ISecret>();
+
+                UnderlyingFactory
+                    .Setup(x => x.CreateSecretReader())
+                    .Returns(() => UnderlyingReader.Object);
+                UnderlyingFactory
+                    .Setup(x => x.CreateSecretInjector(It.IsAny<ISecretReader>()))
+                    .Returns(() => SecretInjector.Object);
+                UnderlyingReader
+                    .Setup(x => x.GetSecretObjectAsync(It.IsAny<string>()))
+                    .ReturnsAsync(() => Secret.Object);
+
+                Target = new RefreshableSecretReaderFactory(
+                    UnderlyingFactory.Object,
+                    Settings);
+            }
+
+            public Mock<ISecretReaderFactory> UnderlyingFactory { get; }
+            public RefreshableSecretReaderSettings Settings { get; }
+            public string SecretName { get; }
+            public Mock<ISecretReader> UnderlyingReader { get; }
+            public Mock<ISecretInjector> SecretInjector { get; }
+            public Mock<ISecret> Secret { get; }
+            public RefreshableSecretReaderFactory Target { get; }
+        }
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/RefreshableSecretReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/RefreshableSecretReaderFacts.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class RefreshableSecretReaderFacts
+    {
+        public class RefreshAsync : Facts
+        {
+            [Fact]
+            public async Task DoesNothingWithEmptyCache()
+            {
+                await Target.RefreshAsync(CancellationToken.None);
+
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task RefreshesAllNames()
+            {
+                await Target.GetSecretAsync(SecretNameA);
+                await Target.GetSecretAsync(SecretNameB);
+                SecretReader.Invocations.Clear();
+
+                await Target.RefreshAsync(CancellationToken.None);
+
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(SecretNameA), Times.Once);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(SecretNameB), Times.Once);
+            }
+
+            [Fact]
+            public async Task CachesLatestValue()
+            {
+                await Target.GetSecretAsync(SecretNameA);
+                SecretReader.Setup(x => x.GetSecretObjectAsync(SecretNameA)).ReturnsAsync(() => SecretB.Object);
+
+                await Target.RefreshAsync(CancellationToken.None);
+
+                var secretObject = await Target.GetSecretObjectAsync(SecretNameA);
+                Assert.Same(SecretB.Object, secretObject);
+            }
+
+            [Fact]
+            public async Task RespectsTheToken()
+            {
+                await Target.GetSecretAsync(SecretNameA);
+                SecretReader.Invocations.Clear();
+                var cts = new CancellationTokenSource();
+                var token = cts.Token;
+                cts.Cancel();
+
+                await Target.RefreshAsync(token);
+
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Never);
+            }
+        }
+
+        public class GetSecretObjectAsync : Facts
+        {
+            [Fact]
+            public async Task FetchesAnUncachedSecret()
+            {
+                var actual = await Target.GetSecretObjectAsync(SecretNameA);
+
+                Assert.Same(SecretA.Object, actual);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(SecretNameA), Times.Once);
+            }
+
+            [Fact]
+            public async Task ReturnsACompletedTaskIfAlreadyCached()
+            {
+                await Target.GetSecretObjectAsync(SecretNameA);
+                SecretReader.Invocations.Clear();
+
+                var task = Target.GetSecretObjectAsync(SecretNameA);
+
+                Assert.Equal(TaskStatus.RanToCompletion, task.Status);
+            }
+
+            [Fact]
+            public async Task DoesNotSwitchThreadIfAlreadyCached()
+            {
+                await Target.GetSecretObjectAsync(SecretNameA);
+                SecretReader.Invocations.Clear();
+                var threadId = Thread.CurrentThread.ManagedThreadId;
+
+                await Target.GetSecretObjectAsync(SecretNameA);
+
+                Assert.Equal(threadId, Thread.CurrentThread.ManagedThreadId);
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task ThrowsIfReadsAreBlocked()
+            {
+                Settings.BlockUncachedReads = true;
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.GetSecretAsync(SecretNameA));
+                Assert.Equal($"The secret '{SecretNameA}' is not cached.", ex.Message);
+            }
+        }
+
+        public class GetSecretAsync : Facts
+        {
+            [Fact]
+            public async Task FetchesAnUncachedSecret()
+            {
+                var actual = await Target.GetSecretAsync(SecretNameA);
+
+                Assert.Same(SecretA.Object.Value, actual);
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(SecretNameA), Times.Once);
+            }
+
+            [Fact]
+            public async Task ReturnsACompletedTaskIfAlreadyCached()
+            {
+                await Target.GetSecretAsync(SecretNameA);
+
+                var task = Target.GetSecretAsync(SecretNameA);
+
+                Assert.Equal(TaskStatus.RanToCompletion, task.Status);
+            }
+
+            [Fact]
+            public async Task DoesNotSwitchThreadIfAlreadyCached()
+            {
+                await Target.GetSecretAsync(SecretNameA);
+                SecretReader.Invocations.Clear();
+                var threadId = Thread.CurrentThread.ManagedThreadId;
+
+                await Target.GetSecretAsync(SecretNameA);
+
+                Assert.Equal(threadId, Thread.CurrentThread.ManagedThreadId);
+                SecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Never);
+                SecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Never);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts()
+            {
+                SecretReader = new Mock<ISecretReader>();
+                Cache = new ConcurrentDictionary<string, ISecret>();
+                Settings = new RefreshableSecretReaderSettings();
+
+                SecretNameA = "A-Name";
+                SecretNameB = "B-Name";
+
+                SecretA = new Mock<ISecret>();
+                SecretB = new Mock<ISecret>();
+
+                SecretA.Setup(x => x.Value).Returns("A-value");
+                SecretB.Setup(x => x.Value).Returns("B-value");
+
+                SecretReader
+                    .Setup(x => x.GetSecretObjectAsync(SecretNameA))
+                    .Returns(async () =>
+                    {
+                        await Task.Yield();
+                        return SecretA.Object;
+                    });
+                SecretReader
+                    .Setup(x => x.GetSecretObjectAsync(SecretNameB))
+                    .Returns(async () =>
+                    {
+                        await Task.Yield();
+                        return SecretB.Object;
+                    });
+
+                Target = new RefreshableSecretReader(
+                    SecretReader.Object,
+                    Cache,
+                    Settings);
+            }
+
+            public Mock<ISecretReader> SecretReader { get; }
+            public ConcurrentDictionary<string, ISecret> Cache { get; }
+            public RefreshableSecretReaderSettings Settings { get; }
+            public string SecretNameA { get; }
+            public string SecretNameB { get; }
+            public Mock<ISecret> SecretA { get; }
+            public Mock<ISecret> SecretB { get; }
+            public RefreshableSecretReader Target { get; }
+        }
+    }
+}


### PR DESCRIPTION
1. Add `RefreshSecretReader`. This returns a secret from cache if it exists. The cache lifetime from this class's perspective is forever. If the secret does not exist in the cache, it will be fetched from an underlying secret reader.

1. Add `RefreshSecretReaderFactory`. This holds the reference to the shared secret cache and has a method `RefreshAsync` which is on `IRefreshSecreReaderFactory` that can be called from a "safe" context, e.g. background thread in a web app.

I added a thing called `BlockUncachedReads` which makes is so non-`RefreshAsync` paths cannot read secrets from KeyVault. In other words it means the secret must be in the cache. This is added so that if we have a bug and a request context tries to read a secret, we throw an exception to fail fast instead of deadlocking.

Progress on https://github.com/NuGet/NuGetGallery/issues/7337.