### PR TITLE
Allow the delay in the feature flag refresh loop to be cancelled

### DIFF
--- a/src/NuGet.Services.FeatureFlags/FeatureFlagCacheService.cs
+++ b/src/NuGet.Services.FeatureFlags/FeatureFlagCacheService.cs
@@ -88,7 +88,15 @@ namespace NuGet.Services.FeatureFlags
                     staleness,
                     _options.RefreshInterval);
 
-                await Task.Delay(_options.RefreshInterval);
+                try
+                {
+                    await Task.Delay(_options.RefreshInterval, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Swallow the cancelled delay operation to allow quiet shutdown of the refresh loop. A cancelled
+                    // delay operation is harmless to the system.
+                }
             }
         }
 


### PR DESCRIPTION
Right now the `RunAsync` task will wait up to `RefreshInterval` before completing even when cancelled.

It can stop immediately allowing faster shutdown.

Related to https://github.com/NuGet/NuGetGallery/issues/7439.