### PR TITLE
Update server common telemetrywrapper to adapt to new interface of IDiagnosticsSource.

### DIFF
--- a/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
+++ b/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.Logging
 {
     public interface ITelemetryClient
     {
+        void TrackTrace(string message, LogLevel logLevel, EventId eventId);
+
         void TrackMetric(
             string metricName,
             double value,

--- a/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
+++ b/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
@@ -7,6 +7,10 @@ using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.Logging
 {
+    /// <summary>
+    /// Interface for the Application Insights TelemetryClient class.
+    /// Notice that NuGetGallery.Services has another interface and implementation for the same functionality.
+    /// </summary>
     public interface ITelemetryClient
     {
         void TrackTrace(string message, LogLevel logLevel, EventId eventId);
@@ -20,5 +24,15 @@ namespace NuGet.Services.Logging
             Exception exception,
             IDictionary<string, string> properties = null,
             IDictionary<string, double> metrics = null);
+
+        void TrackDependency(string dependencyTypeName,
+                             string target,
+                             string dependencyName,
+                             string data,
+                             DateTimeOffset startTime,
+                             TimeSpan duration,
+                             string resultCode,
+                             bool success,
+                             IDictionary<string, string> properties);
     }
 }

--- a/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
+++ b/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
@@ -24,15 +24,5 @@ namespace NuGet.Services.Logging
             Exception exception,
             IDictionary<string, string> properties = null,
             IDictionary<string, double> metrics = null);
-
-        void TrackDependency(string dependencyTypeName,
-                             string target,
-                             string dependencyName,
-                             string data,
-                             DateTimeOffset startTime,
-                             TimeSpan duration,
-                             string resultCode,
-                             bool success,
-                             IDictionary<string, string> properties);
     }
 }

--- a/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
+++ b/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
@@ -71,7 +71,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>2.2.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>

--- a/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
+++ b/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
@@ -70,6 +70,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging">
+      <Version>2.2.0</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -69,7 +69,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>1.0.0</Version>
+      <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.2</Version>

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -69,7 +69,7 @@
       <Version>2.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>2.2.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.2</Version>

--- a/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
@@ -50,6 +50,32 @@ namespace NuGet.Services.Logging
             }
         }
 
+        public void TrackDependency(string dependencyTypeName,
+                                    string target,
+                                    string dependencyName,
+                                    string data,
+                                    DateTimeOffset startTime,
+                                    TimeSpan duration,
+                                    string resultCode,
+                                    bool success,
+                                    IDictionary<string, string> properties)
+        {
+            try
+            {
+                var telemetry = new DependencyTelemetry(dependencyTypeName, target, dependencyName, data, startTime, duration, resultCode, success);
+                foreach (var property in properties)
+                {
+                    telemetry.Properties.Add(property);
+                }
+
+                _telemetryClient.TrackDependency(telemetry);
+            }
+            catch
+            {
+                // logging failed, don't allow exception to escape
+            }
+        }
+
         public void TrackTrace(string message, LogLevel logLevel, EventId eventId)
         {
             try

--- a/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
@@ -50,32 +50,6 @@ namespace NuGet.Services.Logging
             }
         }
 
-        public void TrackDependency(string dependencyTypeName,
-                                    string target,
-                                    string dependencyName,
-                                    string data,
-                                    DateTimeOffset startTime,
-                                    TimeSpan duration,
-                                    string resultCode,
-                                    bool success,
-                                    IDictionary<string, string> properties)
-        {
-            try
-            {
-                var telemetry = new DependencyTelemetry(dependencyTypeName, target, dependencyName, data, startTime, duration, resultCode, success);
-                foreach (var property in properties)
-                {
-                    telemetry.Properties.Add(property);
-                }
-
-                _telemetryClient.TrackDependency(telemetry);
-            }
-            catch
-            {
-                // logging failed, don't allow exception to escape
-            }
-        }
-
         public void TrackTrace(string message, LogLevel logLevel, EventId eventId)
         {
             try


### PR DESCRIPTION
Recently in Gallery.Core, we update the interface of "IDiagnosticsSource" on "TraceEvent", and the new implementation depends on the new member "TraceTrace" in "ITelemetryClient".
Gallery has its own version of "ITelemetryClient" and implementation "TelemetryClientWrapper", while server common has another individual version, which is used by NuGet.Jobs or others.
NuGet.Jobs needs to adapt to the new interface of "IDiagnosticsSource" and implement the updated method "TraceEvent", otherwise the telemetry will be broken, which finally leads to the update of the server common's "ITelemetryClient" and "TelemetryClientWrapper".
The current solution looks a headache for the maintenance work, and we need to have a unified telemetry and diagnostic services.
The Gallery's change is here, and basically the change of this PR follows the Gallery's change:
https://github.com/NuGet/NuGetGallery/pull/7513