### PR TITLE
Don't re-download build tools directory every time

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -30,6 +30,15 @@ Function Get-BuildTools {
         if (-not (Test-Path $DirectoryPath)) {
             New-Item -Path $DirectoryPath -ItemType "directory"
         }
+
+        $MarkerFile = Join-Path $DirectoryPath ".marker"
+        if (Test-Path $MarkerFile) {
+            $content = Get-Content $MarkerFile
+            if ($content -eq $Branch) {
+                Write-Host "Build tools directory '$Path' is already at '$Branch'."
+                return;
+            }
+        }
         
         $FolderUri = "$RootGitHubApiUri/$Path$Ref"
         Write-Host "Downloading files from $FolderUri"
@@ -44,6 +53,8 @@ Function Get-BuildTools {
                 Get-Folder -Path $FilePath
             }
         }
+
+        $Branch | Out-File $MarkerFile
     }
 
     $FoldersToDownload = "build", "tools"


### PR DESCRIPTION
Use a marker file to no-op the download.

I have had situations locally where I get throttled by GitHub because I downloaded too many files from raw.githubusercontent.com using unauthenticated requests.