### PR TITLE
Add traces to emit telemetry initialization and heartbeat config

### DIFF
--- a/src/NuGet.Services.Logging/ApplicationInsights.cs
+++ b/src/NuGet.Services.Logging/ApplicationInsights.cs
@@ -40,7 +40,13 @@ namespace NuGet.Services.Logging
                     if (heartbeatManager != null)
                     {
                         heartbeatManager.HeartbeatInterval = heartbeatInterval.Value;
+
+                        Trace.TraceInformation($"Telemetry initialized using configured heartbeat interval: {heartbeatInterval.Value}.");
                     }
+                }
+                else
+                {
+                    Trace.TraceInformation($"Telemetry initialized using default heartbeat interval.");
                 }
 
                 Initialized = true;


### PR DESCRIPTION
Facilitates debugging potential AI config issues. If `HeartbeatManager` is not configured/found, this will clearly tell us.