### PR TITLE
Align Microsoft.Extensions.Logging dependency for ServerCommon solution

### DIFF
--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -69,7 +69,7 @@
       <Version>2.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>1.0.0</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.2</Version>


### PR DESCRIPTION
Many consumers of ServerCommon dependencies already manually added and upgraded the `Microsoft.Extensions.Logging` dependency to version 1.1.2.

All other ServerCommon libraries already use version 1.1.2. Only `NuGet.Services.Logging` was lagging behind to version 1.0.0.

This PR updates and aligns this dependency for `NuGet.Services.Logging`, and allows us to remove the explicit top-level dependency to `Microsoft.Extensions.Logging` elsewhere, making it a transitive one instead, which makes it easier to maintain our dependencies across the board.