### PR TITLE
Switching to nuget 5.3.1

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -434,7 +434,7 @@ Function Install-NuGet {
 
             Trace-Log 'Downloading nuget.exe'
             Invoke-WebRequest `
-                https://dist.nuget.org/win-x86-commandline/v5.3.0/nuget.exe `
+                https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe `
                 -UseBasicParsing `
                 -OutFile $NuGetExe
             


### PR DESCRIPTION
Should address some of the CredentialProvider issues we are seeing.