### PR TITLE
Work-around heartbeat interval initialization bug in AI

### DIFF
--- a/src/NuGet.Services.Logging/ApplicationInsights.cs
+++ b/src/NuGet.Services.Logging/ApplicationInsights.cs
@@ -9,69 +9,85 @@ using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
 namespace NuGet.Services.Logging
 {
+    /// <summary>
+    /// Utility class to initialize an <see cref="ApplicationInsightsConfiguration"/> instance
+    /// using provided instrumentation key, optional heartbeat interval, 
+    /// and, if detected, taking into account an optional ApplicationInsights.config file.
+    /// </summary>
+    /// <remarks>
+    /// Calling <see cref="Initialize(string)"/> or <see cref="Initialize(string, TimeSpan)"/> returns the
+    /// initialized <see cref="ApplicationInsightsConfiguration"/> object; 
+    /// it does not set the obsolete <see cref="TelemetryClient.Active"/> component.
+    /// 
+    /// It is the caller's responsibility to ensure the returned configuration is used 
+    /// when creating new <see cref="TelemetryClient"/> instances.
+    /// </remarks>
     public static class ApplicationInsights
     {
-        public static IHeartbeatPropertyManager HeartbeatManager { get; private set; }
-
-        public static bool Initialized { get; private set; }
-
-        public static TelemetryConfiguration Initialize(string instrumentationKey)
+        /// <summary>
+        /// Initializes an <see cref="ApplicationInsightsConfiguration"/> using the provided
+        /// <paramref name="instrumentationKey"/>, taking into account the <c>ApplicationInsights.config</c> file if present.
+        /// </summary>
+        /// <param name="instrumentationKey">The instrumentation key to use.</param>
+        public static ApplicationInsightsConfiguration Initialize(string instrumentationKey)
         {
-            return InitializeTelemetryConfiguration(instrumentationKey, heartbeatInterval: null);
+            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval: null);
         }
 
-        public static TelemetryConfiguration Initialize(string instrumentationKey, TimeSpan heartbeatInterval)
+        /// <summary>
+        /// Initializes an <see cref="ApplicationInsightsConfiguration"/> using the provided
+        /// <paramref name="instrumentationKey"/> and <paramref name="heartbeatInterval"/>, 
+        /// taking into account the <c>ApplicationInsights.config</c> file if present.
+        /// </summary>
+        /// <param name="instrumentationKey">The instrumentation key to use.</param>
+        /// <param name="heartbeatInterval">The heartbeat interval to use.</param>
+        public static ApplicationInsightsConfiguration Initialize(
+            string instrumentationKey,
+            TimeSpan heartbeatInterval)
         {
-            return InitializeTelemetryConfiguration(instrumentationKey, heartbeatInterval);
+            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval);
         }
 
-        private static TelemetryConfiguration InitializeTelemetryConfiguration(string instrumentationKey, TimeSpan? heartbeatInterval)
+        private static ApplicationInsightsConfiguration InitializeApplicationInsightsConfiguration(
+            string instrumentationKey,
+            TimeSpan? heartbeatInterval)
         {
-            TelemetryConfiguration telemetryConfiguration = null;
+            // Note: TelemetryConfiguration.Active is being deprecated
+            // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152
+            // We use TelemetryConfiguration.CreateDefault() as opposed to instantiating a new TelemetryConfiguration()
+            // to take into account the ApplicationInsights.config file (if detected).
+            var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                // Note: TelemetryConfiguration.Active is being deprecated
-                // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152
-
-                telemetryConfiguration = TelemetryConfiguration.CreateDefault();
                 telemetryConfiguration.InstrumentationKey = instrumentationKey;
-                telemetryConfiguration.TelemetryInitializers.Add(new TelemetryContextInitializer());
+            }
 
-                // Construct a TelemetryClient to emit traces so we can track and debug AI initialization.
-                var telemetryClient = new TelemetryClient(telemetryConfiguration);
+            telemetryConfiguration.TelemetryInitializers.Add(new TelemetryContextInitializer());
 
-                telemetryClient.TrackTrace(
-                            $"TelemetryConfiguration initialized using instrumentation key: {instrumentationKey}.",
-                            SeverityLevel.Information);
+            // Construct a TelemetryClient to emit traces so we can track and debug AI initialization.
+            var telemetryClient = new TelemetryClient(telemetryConfiguration);
 
-                // Configure heartbeat interval if specified.
-                // When not defined or null, the DiagnosticsTelemetryModule will use its internal defaults (heartbeat enabled, interval of 15 minutes).
-                if (heartbeatInterval.HasValue)
-                {
-                    var diagnosticsTelemetryModule = new DiagnosticsTelemetryModule();
-                    diagnosticsTelemetryModule.HeartbeatInterval = heartbeatInterval.Value;
-                    diagnosticsTelemetryModule.Initialize(telemetryConfiguration);
-
-                    telemetryClient.TrackTrace(
-                            $"DiagnosticsTelemetryModule initialized using configured heartbeat interval: {heartbeatInterval.Value}.",
-                            SeverityLevel.Information);
-                }
-                else
-                {
-                    telemetryClient.TrackTrace(
-                        "Telemetry initialized using default heartbeat interval.",
+            telemetryClient.TrackTrace(
+                        $"TelemetryConfiguration initialized using instrumentation key: {instrumentationKey ?? "EMPTY"}.",
                         SeverityLevel.Information);
-                }
 
-                Initialized = true;
-            }
-            else
+            var diagnosticsTelemetryModule = new DiagnosticsTelemetryModule();
+
+            // Configure heartbeat interval if specified.
+            // When not defined, the DiagnosticsTelemetryModule will use its internal defaults (heartbeat enabled, interval of 15 minutes).
+            var traceMessage = "DiagnosticsTelemetryModule initialized using default heartbeat interval.";
+            if (heartbeatInterval.HasValue)
             {
-                Initialized = false;
+                diagnosticsTelemetryModule.HeartbeatInterval = heartbeatInterval.Value;
+                traceMessage = $"DiagnosticsTelemetryModule initialized using configured heartbeat interval: {heartbeatInterval.Value}.";
             }
 
-            return telemetryConfiguration;
+            diagnosticsTelemetryModule.Initialize(telemetryConfiguration);
+
+            telemetryClient.TrackTrace(traceMessage, SeverityLevel.Information);
+
+            return new ApplicationInsightsConfiguration(telemetryConfiguration, diagnosticsTelemetryModule);
         }
     }
 }

--- a/src/NuGet.Services.Logging/ApplicationInsightsConfiguration.cs
+++ b/src/NuGet.Services.Logging/ApplicationInsightsConfiguration.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+namespace NuGet.Services.Logging
+{
+    public sealed class ApplicationInsightsConfiguration
+    {
+        internal ApplicationInsightsConfiguration(
+            TelemetryConfiguration telemetryConfiguration,
+            DiagnosticsTelemetryModule diagnosticsTelemetryModule)
+        {
+            TelemetryConfiguration = telemetryConfiguration ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
+            DiagnosticsTelemetryModule = diagnosticsTelemetryModule ?? throw new ArgumentNullException(nameof(diagnosticsTelemetryModule));
+        }
+
+        /// <summary>
+        /// Contains the initialized <see cref="Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration"/>.
+        /// Used to initialize new <see cref="Microsoft.ApplicationInsights.TelemetryClient"/> instances.
+        /// Allows tweaking telemetry initializers.
+        /// </summary>
+        /// <remarks>
+        /// Needs to be disposed when gracefully shutting down the application.
+        /// </remarks>
+        public TelemetryConfiguration TelemetryConfiguration { get; }
+
+        /// <summary>
+        /// Contains the initialized <see cref="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule"/>.
+        /// Allows tweaking Application Insights heartbeat telemetry.
+        /// </summary>
+        public DiagnosticsTelemetryModule DiagnosticsTelemetryModule { get; }
+    }
+}

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationInsights.cs" />
+    <Compile Include="ApplicationInsightsConfiguration.cs" />
     <Compile Include="DurationMetric.cs" />
     <Compile Include="ExceptionTelemetryProcessor.cs" />
     <Compile Include="LoggingSetup.cs" />

--- a/tests/NuGet.Services.Logging.Tests/ApplicationInsightsTests.cs
+++ b/tests/NuGet.Services.Logging.Tests/ApplicationInsightsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Services.Logging.Tests
+{
+    public class ApplicationInsightsTests
+    {
+        private const string InstrumentationKey = "abcdef12-3456-7890-abcd-ef123456789";
+
+        [Fact]
+        public void InitializeReturnsApplicationInsightsConfiguration()
+        {
+            var applicationInsightsConfiguration = ApplicationInsights.Initialize(InstrumentationKey);
+
+            Assert.NotNull(applicationInsightsConfiguration);
+            Assert.Equal(InstrumentationKey, applicationInsightsConfiguration.TelemetryConfiguration.InstrumentationKey);
+        }
+
+        [Fact]
+        public void InitializeRegistersTelemetryContextInitializer()
+        {
+            var applicationInsightsConfiguration = ApplicationInsights.Initialize(InstrumentationKey);
+            Assert.Contains(applicationInsightsConfiguration.TelemetryConfiguration.TelemetryInitializers, ti => ti is TelemetryContextInitializer);
+        }
+
+        [Fact]
+        public void InitializeSetsHeartbeatIntervalAndDiagnosticsTelemetryModule()
+        {
+            var heartbeatInterval = TimeSpan.FromMinutes(1);
+
+            var applicationInsightsConfiguration = ApplicationInsights.Initialize(InstrumentationKey, heartbeatInterval);
+
+            Assert.NotNull(applicationInsightsConfiguration.DiagnosticsTelemetryModule);
+            Assert.Equal(heartbeatInterval, applicationInsightsConfiguration.DiagnosticsTelemetryModule.HeartbeatInterval);
+        }
+    }
+}

--- a/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
+++ b/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
@@ -53,6 +53,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationInsightsTests.cs" />
     <Compile Include="ExceptionTelemetryProcessorTests.cs" />
     <Compile Include="LoggingSetupTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Verified changes locally against the solution that reproduced the AppInsights bug, and this work-around works.

Also need to verify our usage of `TelemetryConfiguration.Active` throughout the code consuming this library, as that API is being deprecated, and `TelemetryConfiguration.Active` won't pick up this custom initialized instance.