### PR TITLE
Support already configured TelemetryConfiguration for LoggingSetup

### DIFF
--- a/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
@@ -59,7 +59,7 @@ namespace NuGet.Services.Logging
                 {
                     Timestamp = timestamp,
                     Name = metricName,
-                    Value = value
+                    Sum = value
                 };
 
                 if (properties != null)


### PR DESCRIPTION
The `LoggingSetup` should no longer use the `TelemetryConfiguration.Active` static, and must support providing an already configured `TelemetryConfiguration` instance again.

Even though this method call is marked `[Obsolete]` for this SeriLog sink, there's currently no other way to pass in the active `TelemetryConfiguration` as configured in DI.

These SeriLog APIs are very likely to change again to support passing in the `TelemetryConfiguration` somehow, in light of `TelemetryConfiguration.Active` being deprecated by AI.

See also https://github.com/serilog/serilog-sinks-applicationinsights/issues/121.