### PR TITLE
Port MachineNameTelemetryInitializer from NuGet.ApplicationInsights.Owin

### DIFF
--- a/src/NuGet.Services.Logging/TelemetryInitializers/MachineNameTelemetryInitializer.cs
+++ b/src/NuGet.Services.Logging/TelemetryInitializers/MachineNameTelemetryInitializer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.Logging
+{
+    public class MachineNameTelemetryInitializer
+        : SupportPropertiesTelemetryInitializer
+    {
+        public MachineNameTelemetryInitializer()
+            : base("MachineName", TryGetMachineName())
+        {
+        }
+
+        private static string TryGetMachineName()
+        {
+            try
+            {
+                return Environment.MachineName;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This type belongs in `NuGet.Services.Logging` as it can be generally reused and is not specific to `Owin`.

In addition, there's no need to retrieve the machine name from `Environment.MachineName` on every telemetry initialization, which may happen multiple times for the same telemetry item.