### PR TITLE
Update Owin/IdentityModel packages

### DIFF
--- a/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
+++ b/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>3.19.4</Version>
+      <Version>5.2.6</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.2</Version>

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -79,7 +79,7 @@
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>3.19.4</Version>
+      <Version>5.2.6</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.2</Version>

--- a/src/NuGet.Services.Owin/NuGet.Services.Owin.csproj
+++ b/src/NuGet.Services.Owin/NuGet.Services.Owin.csproj
@@ -61,7 +61,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>

--- a/src/NuGet.Services.Sql/AzureSqlConnectionStringBuilder.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionStringBuilder.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.Sql
     /// </summary>
     public class AzureSqlConnectionStringBuilder : DbConnectionStringBuilder
     {
-        private const string AadAuthorityTemplate = "https://login.microsoftonline.com/{0}/v2.0";
+        private const string AadAuthorityTemplate = "https://login.microsoftonline.com/{0}";
 
         public string AadAuthority { get; }
 

--- a/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
+++ b/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
@@ -74,7 +74,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>3.19.4</Version>
+      <Version>5.2.6</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks.Pack">
       <Version>4.8.0</Version>

--- a/tests/NuGet.Services.Owin.Tests/NuGet.Services.Owin.Tests.csproj
+++ b/tests/NuGet.Services.Owin.Tests/NuGet.Services.Owin.Tests.csproj
@@ -48,7 +48,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>


### PR DESCRIPTION
Updating the Owin and Identity Model packages as part of the SameSite cookie mitigation work going into the NuGetGallery.

NuGet.Services.Sql needs an update to the AAD authority template as the authority resolution changed as described at https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1346