### PR TITLE
[ECR] Populate logger to have better telemetry

### DIFF
--- a/src/NuGet.Services.KeyVault/CachingSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/CachingSecretReader.cs
@@ -64,7 +64,7 @@ namespace NuGet.Services.KeyVault
 
             logger?.LogInformation("Refresh secret {SecretName}{ExpirationTime} (Latency = {ElapsedMilliseconds}ms)",
                 updatedValue.Secret.Name,
-                updatedValue.Secret.Expiration == null ? "" : " which expires at " + ((DateTimeOffset) updatedValue.Secret.Expiration).DateTime,
+                updatedValue.Secret.Expiration == null ? "" : " which expires at " + ((DateTimeOffset) updatedValue.Secret.Expiration).UtcDateTime,
                 (DateTimeOffset.UtcNow - start).TotalMilliseconds.ToString("F2"));
 
             return _cache.AddOrUpdate(secretName, updatedValue, (key, old) => updatedValue).Secret;

--- a/src/NuGet.Services.KeyVault/CachingSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/CachingSecretReader.cs
@@ -58,14 +58,14 @@ namespace NuGet.Services.KeyVault
                 return result.Secret;
             }
 
-            var start = DateTimeOffset.Now;
+            var start = DateTimeOffset.UtcNow;
             // The cache does not contain a fresh copy of the secret. Fetch and cache the secret.
             var updatedValue = new CachedSecret(await _internalReader.GetSecretObjectAsync(secretName));
 
             logger?.LogInformation("Refresh secret {SecretName}{ExpirationTime} (Latency = {ElapsedMilliseconds}ms)",
                 updatedValue.Secret.Name,
                 updatedValue.Secret.Expiration == null ? "" : " which expires at " + ((DateTimeOffset) updatedValue.Secret.Expiration).DateTime,
-                (DateTimeOffset.Now - start).TotalMilliseconds.ToString("F2"));
+                (DateTimeOffset.UtcNow - start).TotalMilliseconds.ToString("F2"));
 
             return _cache.AddOrUpdate(secretName, updatedValue, (key, old) => updatedValue).Secret;
         }

--- a/src/NuGet.Services.KeyVault/CachingSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/CachingSecretReader.cs
@@ -29,9 +29,9 @@ namespace NuGet.Services.KeyVault
             _refreshIntervalBeforeExpiry = TimeSpan.FromSeconds(refreshIntervalBeforeExpirySec);
         }
 
-        public Task<string> GetSecretAsync(string secretName)
+        public async Task<string> GetSecretAsync(string secretName)
         {
-            return GetSecretAsync(secretName, logger: null);
+            return await GetSecretAsync(secretName, logger: null);
         }
 
         public async Task<string> GetSecretAsync(string secretName, ILogger logger)
@@ -39,9 +39,9 @@ namespace NuGet.Services.KeyVault
             return (await GetSecretObjectAsync(secretName, logger)).Value;
         }
 
-        public Task<ISecret> GetSecretObjectAsync(string secretName)
+        public async Task<ISecret> GetSecretObjectAsync(string secretName)
         {
-            return GetSecretObjectAsync(secretName, logger: null);
+            return await GetSecretObjectAsync(secretName, logger: null);
         }
 
         public async Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
@@ -62,9 +62,9 @@ namespace NuGet.Services.KeyVault
             // The cache does not contain a fresh copy of the secret. Fetch and cache the secret.
             var updatedValue = new CachedSecret(await _internalReader.GetSecretObjectAsync(secretName));
 
-            logger?.LogInformation("Refresh secret {SecretName}{ExpirationTime} (Latency = {ElapsedMilliseconds}ms)",
+            logger?.LogInformation("Refreshed secret {SecretName}, Expiring at: {ExpirationTime}. Took {ElapsedMilliseconds}ms.",
                 updatedValue.Secret.Name,
-                updatedValue.Secret.Expiration == null ? "" : " which expires at " + ((DateTimeOffset) updatedValue.Secret.Expiration).UtcDateTime,
+                updatedValue.Secret.Expiration == null ? "null" : ((DateTimeOffset) updatedValue.Secret.Expiration).UtcDateTime.ToString(),
                 (DateTimeOffset.UtcNow - start).TotalMilliseconds.ToString("F2"));
 
             return _cache.AddOrUpdate(secretName, updatedValue, (key, old) => updatedValue).Secret;

--- a/src/NuGet.Services.KeyVault/EmptySecretReader.cs
+++ b/src/NuGet.Services.KeyVault/EmptySecretReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault
 {
@@ -9,12 +10,22 @@ namespace NuGet.Services.KeyVault
     {
         public Task<string> GetSecretAsync(string secretName)
         {
+            return GetSecretAsync(secretName, logger: null);
+        }
+
+        public Task<string> GetSecretAsync(string secretName, ILogger logger)
+        {
             return Task.FromResult(secretName);
-        }        
+        }
 
         public Task<ISecret> GetSecretObjectAsync(string secretName)
-        {            
+        {
+            return GetSecretObjectAsync(secretName, logger: null);
+        }
+
+        public Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
+        {
             return Task.FromResult((ISecret)new KeyVaultSecret(secretName, secretName, null));
-        }        
+        }
     }
 }

--- a/src/NuGet.Services.KeyVault/ISecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/ISecretInjector.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault
 {
     public interface ISecretInjector
     {
         Task<string> InjectAsync(string input);
+        Task<string> InjectAsync(string input, ILogger logger);
     }
 }

--- a/src/NuGet.Services.KeyVault/ISecretReader.cs
+++ b/src/NuGet.Services.KeyVault/ISecretReader.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault
 {
     public interface ISecretReader
     {
         Task<string> GetSecretAsync(string secretName);
+        Task<string> GetSecretAsync(string secretName, ILogger logger);
         Task<ISecret> GetSecretObjectAsync(string secretName);
+        Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger);
     }
 }

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace NuGet.Services.KeyVault
@@ -32,13 +33,23 @@ namespace NuGet.Services.KeyVault
             _keyVaultClient = new Lazy<KeyVaultClient>(InitializeClient);
         }
 
-        public async Task<string> GetSecretAsync(string secretName)
+        public Task<string> GetSecretAsync(string secretName)
+        {
+            return GetSecretAsync(secretName, logger: null);
+        }
+
+        public async Task<string> GetSecretAsync(string secretName, ILogger logger)
         {
             var secret = await _keyVaultClient.Value.GetSecretAsync(_vault, secretName);
             return secret.Value;
         }
 
-        public async Task<ISecret> GetSecretObjectAsync(string secretName)
+        public Task<ISecret> GetSecretObjectAsync(string secretName)
+        {
+            return GetSecretObjectAsync(secretName, logger: null);
+        }
+
+        public async Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
         {
             var secret = await _keyVaultClient.Value.GetSecretAsync(_vault, secretName);
             return new KeyVaultSecret(secretName, secret.Value, secret.Attributes.Expires);

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -33,9 +33,9 @@ namespace NuGet.Services.KeyVault
             _keyVaultClient = new Lazy<KeyVaultClient>(InitializeClient);
         }
 
-        public Task<string> GetSecretAsync(string secretName)
+        public async Task<string> GetSecretAsync(string secretName)
         {
-            return GetSecretAsync(secretName, logger: null);
+            return await GetSecretAsync(secretName, logger: null);
         }
 
         public async Task<string> GetSecretAsync(string secretName, ILogger logger)
@@ -44,9 +44,9 @@ namespace NuGet.Services.KeyVault
             return secret.Value;
         }
 
-        public Task<ISecret> GetSecretObjectAsync(string secretName)
+        public async Task<ISecret> GetSecretObjectAsync(string secretName)
         {
-            return GetSecretObjectAsync(secretName, logger: null);
+            return await GetSecretObjectAsync(secretName, logger: null);
         }
 
         public async Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -81,6 +81,9 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication">
       <Version>1.3.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>2.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>5.2.6</Version>
     </PackageReference>

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReader.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault
 {
@@ -46,6 +47,11 @@ namespace NuGet.Services.KeyVault
 
         public Task<string> GetSecretAsync(string secretName)
         {
+            return GetSecretAsync(secretName, logger: null);
+        }
+
+        public Task<string> GetSecretAsync(string secretName, ILogger logger)
+        {
             if (TryGetCachedSecretObject(secretName, out var secret))
             {
                 return Task.FromResult(secret.Value);
@@ -55,6 +61,11 @@ namespace NuGet.Services.KeyVault
         }
 
         public Task<ISecret> GetSecretObjectAsync(string secretName)
+        {
+            return GetSecretObjectAsync(secretName, logger: null);
+        }
+
+        public Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
         {
             if (TryGetCachedSecretObject(secretName, out var secret))
             {

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault
 {
@@ -34,7 +35,12 @@ namespace NuGet.Services.KeyVault
             _secretReader = secretReader;
         }
 
-        public async Task<string> InjectAsync(string input)
+        public Task<string> InjectAsync(string input)
+        {
+            return InjectAsync(input, logger: null);
+        }
+
+        public async Task<string> InjectAsync(string input, ILogger logger)
         {
             if (string.IsNullOrEmpty(input))
             {
@@ -46,7 +52,7 @@ namespace NuGet.Services.KeyVault
 
             foreach (var secretName in secretNames)
             {
-                var secretValue = await _secretReader.GetSecretAsync(secretName);
+                var secretValue = await _secretReader.GetSecretAsync(secretName, logger);
                 output.Replace($"{_frame}{secretName}{_frame}", secretValue);
             }
 

--- a/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
@@ -76,7 +76,7 @@ namespace NuGet.Services.Sql
 
             if (!string.IsNullOrWhiteSpace(ConnectionString.AadAuthority))
             {
-                var clientCertificateData = await SecretInjector.InjectAsync(ConnectionString.AadCertificate);
+                var clientCertificateData = await SecretInjector.InjectAsync(ConnectionString.AadCertificate, Logger);
                 if (!string.IsNullOrEmpty(clientCertificateData))
                 {
                     connection.AccessToken = await AcquireAccessTokenAsync(clientCertificateData);

--- a/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
-using NuGet.Services.KeyVault;
 using Microsoft.Extensions.Logging;
+using NuGet.Services.KeyVault;
 
 namespace NuGet.Services.Sql
 {
@@ -71,7 +71,7 @@ namespace NuGet.Services.Sql
 
         private async Task<SqlConnection> ConnectAsync()
         {
-            var connectionString = await SecretInjector.InjectAsync(ConnectionString.ConnectionString);
+            var connectionString = await SecretInjector.InjectAsync(ConnectionString.ConnectionString, Logger);
             var connection = new SqlConnection(connectionString);
 
             if (!string.IsNullOrWhiteSpace(ConnectionString.AadAuthority))

--- a/tests/NuGet.Services.KeyVault.Tests/CachingSecretReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/CachingSecretReaderFacts.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
 using Moq;
 using Xunit;
 
@@ -15,9 +17,39 @@ namespace NuGet.Services.KeyVault.Tests
         {
             // Arrange
             const string secretName = "secretname";
-            const string secretValue = "testValue";            
-            KeyVaultSecret secret = new KeyVaultSecret(secretName, secretValue, null);            
+            const string secretValue = "testValue";
+            KeyVaultSecret secret = new KeyVaultSecret(secretName, secretValue, null);
 
+            var mockSecretReader = new Mock<ISecretReader>();
+            mockSecretReader
+                .Setup(x => x.GetSecretObjectAsync(It.IsAny<string>()))
+                .Returns(Task.FromResult((ISecret)secret));
+            var mockLogger = new Mock<ILogger>();
+
+            var cachingSecretReader = new CachingSecretReader(mockSecretReader.Object, int.MaxValue);
+
+            // Act
+            var value1 = await cachingSecretReader.GetSecretAsync("secretname", mockLogger.Object);
+            var value2 = await cachingSecretReader.GetSecretAsync("secretname", mockLogger.Object);
+
+            // Assert
+            mockSecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Once);
+            mockLogger.Verify(x => x.Log(It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<FormattedLogValues>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WhenGetSecretIsCalledCacheIsUsedWithoutLogger()
+        {
+            // Arrange
+            const string secretName = "secretname";
+            const string secretValue = "testValue";
+            KeyVaultSecret secret = new KeyVaultSecret(secretName, secretValue, null);
+
+            var mockLogger = new Mock<ILogger>();
             var mockSecretReader = new Mock<ISecretReader>();
             mockSecretReader
                 .Setup(x => x.GetSecretObjectAsync(It.IsAny<string>()))
@@ -31,8 +63,11 @@ namespace NuGet.Services.KeyVault.Tests
 
             // Assert
             mockSecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Once);
-            Assert.Equal(secretValue, value1);
-            Assert.Equal(value1, value2);
+            mockLogger.Verify(x => x.Log(It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<FormattedLogValues>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Never);
         }
 
         [Fact]
@@ -47,20 +82,25 @@ namespace NuGet.Services.KeyVault.Tests
             const int refreshIntervalSec = 1;
 
             var mockSecretReader = new Mock<ISecretReader>();
-
             mockSecretReader
                 .SetupSequence(x => x.GetSecretObjectAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult((ISecret)firstSecret))
                 .Returns(Task.FromResult((ISecret)secondSecret));
+            var mockLogger = new Mock<ILogger>();
 
             var cachingSecretReader = new CachingSecretReader(mockSecretReader.Object, refreshIntervalSec);
 
             // Act
-            var firstValue1 = await cachingSecretReader.GetSecretAsync(secretName);
-            var firstValue2 = await cachingSecretReader.GetSecretAsync(secretName);
+            var firstValue1 = await cachingSecretReader.GetSecretAsync(secretName, mockLogger.Object);
+            var firstValue2 = await cachingSecretReader.GetSecretAsync(secretName, mockLogger.Object);
 
             // Assert
             mockSecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Once);
+            mockLogger.Verify(x => x.Log(It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<FormattedLogValues>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Once);
             Assert.Equal(firstSecret.Value, firstValue1);
             Assert.Equal(firstSecret.Value, firstValue2);
 
@@ -69,11 +109,16 @@ namespace NuGet.Services.KeyVault.Tests
             await Task.Delay(TimeSpan.FromSeconds(refreshIntervalSec * 2));
 
             // Act 2
-            var secondValue1 = await cachingSecretReader.GetSecretAsync(secretName);
-            var secondValue2 = await cachingSecretReader.GetSecretAsync(secretName);
+            var secondValue1 = await cachingSecretReader.GetSecretAsync(secretName, mockLogger.Object);
+            var secondValue2 = await cachingSecretReader.GetSecretAsync(secretName, mockLogger.Object);
 
             // Assert 2
             mockSecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Exactly(2));
+            mockLogger.Verify(x => x.Log(It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<FormattedLogValues>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Exactly(2));
             Assert.Equal(secondSecret.Value, secondValue1);
             Assert.Equal(secondSecret.Value, secondValue2);
         }
@@ -97,16 +142,22 @@ namespace NuGet.Services.KeyVault.Tests
                 .SetupSequence(x => x.GetSecretObjectAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult((ISecret)secret1))
                 .Returns(Task.FromResult((ISecret)secret2));
+            var mockLogger = new Mock<ILogger>();
 
             var cachingSecretReader = new CachingSecretReader(mockSecretReader.Object, refreshIntervalSec, refreshIntervalBeforeExpirySec);
 
             // Act
-            var secretObject1 = await cachingSecretReader.GetSecretObjectAsync(secretName);
-            var secretObject2 = await cachingSecretReader.GetSecretObjectAsync(secretName);
-            var secretObject3 = await cachingSecretReader.GetSecretObjectAsync(secretName);
+            var secretObject1 = await cachingSecretReader.GetSecretObjectAsync(secretName, mockLogger.Object);
+            var secretObject2 = await cachingSecretReader.GetSecretObjectAsync(secretName, mockLogger.Object);
+            var secretObject3 = await cachingSecretReader.GetSecretObjectAsync(secretName, mockLogger.Object);
 
             // Assert
             mockSecretReader.Verify(x => x.GetSecretObjectAsync(It.IsAny<string>()), Times.Exactly(2));
+            mockLogger.Verify(x => x.Log(It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<FormattedLogValues>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Exactly(2));
             Assert.Equal(secretObject1.Value, firstSecretValue);
             Assert.Equal(secretObject1.Expiration, firstSecretExpiration);
             Assert.Equal(secretObject2.Value, secondSecretValue);

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.KeyVault.Tests
 {
@@ -55,7 +56,8 @@ namespace NuGet.Services.KeyVault.Tests
         public KeyVaultReaderFormatterFacts()
         {
             var mockKeyVault = new Mock<ISecretReader>();
-            mockKeyVault.Setup(x => x.GetSecretAsync(It.IsAny<string>())).Returns((string s) => Task.FromResult(s.ToUpper()));
+            mockKeyVault.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+                .Returns((string s, ILogger logger) => Task.FromResult(s.ToUpper()));
 
             _secretInjector = new SecretInjector(mockKeyVault.Object);
         }

--- a/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionFactoryFacts.cs
+++ b/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionFactoryFacts.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Moq;
-using NuGet.Services.KeyVault;
 using Xunit;
+using NuGet.Services.KeyVault;
 
 namespace NuGet.Services.Sql.Tests
 {
@@ -53,9 +54,9 @@ namespace NuGet.Services.Sql.Tests
                 var connection = await ConnectAsync(factory, shouldOpen);
 
                 // Assert
-                factory.MockSecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>()), Times.Exactly(2));
-                factory.MockSecretReader.Verify(x => x.GetSecretAsync("user"), Times.Once);
-                factory.MockSecretReader.Verify(x => x.GetSecretAsync("pass"), Times.Once);
+                factory.MockSecretReader.Verify(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<ILogger>()), Times.Exactly(2));
+                factory.MockSecretReader.Verify(x => x.GetSecretAsync("user", It.IsAny<ILogger>()), Times.Once);
+                factory.MockSecretReader.Verify(x => x.GetSecretAsync("pass", It.IsAny<ILogger>()), Times.Once);
 
                 Assert.True(connection.ConnectionString.Equals(
                     $"{MockConnectionStrings.BaseConnectionString};User ID=user;Password=pass", StringComparison.InvariantCultureIgnoreCase));
@@ -75,7 +76,7 @@ namespace NuGet.Services.Sql.Tests
                 var connection = await ConnectAsync(factory, shouldOpen);
 
                 // Assert
-                factory.MockSecretReader.Verify(x => x.GetSecretAsync("cert"), Times.Once);
+                factory.MockSecretReader.Verify(x => x.GetSecretAsync("cert", It.IsAny<ILogger>()), Times.Once);
 
                 // Note that AAD keys are extracted for internal use only
                 Assert.True(connection.ConnectionString.Equals(

--- a/tests/NuGet.Services.Sql.Tests/MockFactory.cs
+++ b/tests/NuGet.Services.Sql.Tests/MockFactory.cs
@@ -4,6 +4,7 @@
 using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Moq;
+using Microsoft.Extensions.Logging;
 using NuGet.Services.KeyVault;
 
 namespace NuGet.Services.Sql.Tests
@@ -43,8 +44,8 @@ namespace NuGet.Services.Sql.Tests
         {
             var mockSecretReader = new Mock<ISecretReader>();
 
-            mockSecretReader.Setup(x => x.GetSecretAsync(It.IsAny<string>()))
-                .Returns<string>(key =>
+            mockSecretReader.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
+                .Returns<string, ILogger>((key, loger) =>
                 {
                     return Task.FromResult(key.Replace("$$", string.Empty));
                 })

--- a/tests/NuGet.Services.Sql.Tests/MockFactory.cs
+++ b/tests/NuGet.Services.Sql.Tests/MockFactory.cs
@@ -45,7 +45,7 @@ namespace NuGet.Services.Sql.Tests
             var mockSecretReader = new Mock<ISecretReader>();
 
             mockSecretReader.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
-                .Returns<string, ILogger>((key, loger) =>
+                .Returns<string, ILogger>((key, logger) =>
                 {
                     return Task.FromResult(key.Replace("$$", string.Empty));
                 })


### PR DESCRIPTION
Currently we don't have the logs around the caching control of secret reader.
In order to understand the on-line behavior of certificates (SQL), try to populate the logger to the corresponding parts. 