### PR TITLE
Add StringArrayConverter to handle string arrays in Gallery-style config

### DIFF
--- a/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
+++ b/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="SecretConfigurationReader.cs" />
     <Compile Include="SecretDictionary.cs" />
+    <Compile Include="StringArrayConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.Configuration/StringArrayConverter.cs
+++ b/src/NuGet.Services.Configuration/StringArrayConverter.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace NuGet.Services.Configuration
+{
+    public class StringArrayConverter : ArrayConverter
+    {
+        private static readonly string[] EmptyArray = new string[0];
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            var s = value as string;
+            if (s != null)
+            {
+                if (s == string.Empty)
+                {
+                    return EmptyArray;
+                }
+                else
+                {
+                    return s.Split(';');
+                }
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/tests/NuGet.Services.Configuration.Tests/NuGet.Services.Configuration.Tests.csproj
+++ b/tests/NuGet.Services.Configuration.Tests/NuGet.Services.Configuration.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="MicrosoftExtensionsConfigurationIntegrationFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SecretDictionaryFacts.cs" />
+    <Compile Include="StringArrayConverterFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">

--- a/tests/NuGet.Services.Configuration.Tests/StringArrayConverterFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/StringArrayConverterFacts.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using Xunit;
+
+namespace NuGet.Services.Configuration.Tests
+{
+    public class StringArrayConverterFacts
+    {
+        [Fact]
+        public void CanConvertFromString()
+        {
+            var target = new StringArrayConverter();
+
+            Assert.True(target.CanConvertFrom(typeof(string)));
+        }
+
+        [Fact]
+        public void SplitsStringBySemicolon()
+        {
+            var target = new StringArrayConverter();
+
+            var output = target.ConvertFrom("foo;bar  ;  baz");
+
+            var array = Assert.IsType<string[]>(output);
+            Assert.Equal(new[] { "foo", "bar  ", "  baz" }, array);
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("foo bar")]
+        [InlineData("foo|bar")]
+        [InlineData("foo,bar")]
+        [InlineData("   ")]
+        public void ReturnsSingleStringWhenThereIsNoDelimeter(string input)
+        {
+            var target = new StringArrayConverter();
+
+            var output = target.ConvertFrom(input);
+
+            var array = Assert.IsType<string[]>(output);
+            Assert.Equal(new[] { input }, array);
+        }
+
+        [Fact]
+        public void ReturnsEmptyArrayWithEmpty()
+        {
+            var target = new StringArrayConverter();
+
+            var output = target.ConvertFrom(string.Empty);
+
+            var array = Assert.IsType<string[]>(output);
+            Assert.Empty(array);
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3020

We have some internal configuration that we want to pull into the private build of gallery that has an array configuration variable. The way we do configuration in gallery is via `TypeConverter`/component model stuff and our config comes from string to string pairs. Therefore if the configuration model has a string array in it, this is how we handle it.

Note that we already have the implementation here in gallery:
https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery.Services/Helpers/StringArrayConverter.cs

However I'd like to move it to a common place so that an internal project that gallery will depend on with build magic can use it too.