### PR TITLE
Remove unnecessary dependencies to fix Component Governance

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -532,6 +532,13 @@ Function Install-DotnetCLI {
         Error-Log "Unable to find dotnet.exe. The CLI install may have failed." -Fatal
     }
 
+    # Delete a project template that is unused and is causing a Component Governance issue.
+    # See https://github.com/dotnet/aspnetcore/issues/20001
+    $templatesToRemove = Get-ChildItem (Join-Path $CLIRoot "sdk\**\Templates\microsoft.dotnet.web.projecttemplate*")
+    Trace-Log "Removing items: "
+    $templatesToRemove
+    $templatesToRemove | Remove-Item -Force -Recurse
+
     # Display build info
     & $DotNetExe --info
 }

--- a/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
+++ b/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
@@ -74,9 +74,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.RegularExpressions">
-      <Version>4.3.0</Version>
-    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <SignType Condition="'$(SignType)' == ''">none</SignType>

--- a/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
+++ b/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
@@ -40,9 +40,6 @@
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>
     </PackageReference>
-    <PackageReference Include="SerilogTraceListener">
-      <Version>2.0.10027</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>


### PR DESCRIPTION
We should not using the System.Text.RegularExpressions 4.3.0 package.
Remove a problematic template from our .NET CLI installation. This is the easiest way for us to work-around the issue. I have filed a but against the template owners but we should not be blocked on this.