### PR TITLE
Set assembly version to 2.0.0.0 for all builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -63,29 +63,29 @@ Invoke-BuildStep 'Clearing artifacts' { Clear-Artifacts } `
 
 Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
         $versionMetadata = `
-            "$PSScriptRoot\src\NuGet.Services.KeyVault\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Logging\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Configuration\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Build\Properties\AssemblyInfo.g.cs",`
-            "$PSScriptRoot\src\NuGet.Services.Storage\Properties\AssemblyInfo.g.cs",`
-            "$PSScriptRoot\src\NuGet.Services.Cursor\Properties\AssemblyInfo.g.cs",`
-            "$PSScriptRoot\src\NuGet.Services.Owin\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.AzureManagement\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Build\Properties\AssemblyInfo.g.cs",`
+            "$PSScriptRoot\src\NuGet.Services.Configuration\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Contracts\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.ServiceBus\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Validation\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Validation.Issues\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Incidents\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Sql\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Status\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Status.Table\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Messaging\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Messaging.Email\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Cursor\Properties\AssemblyInfo.g.cs",`
             "$PSScriptRoot\src\NuGet.Services.FeatureFlags\Properties\AssemblyInfo.g.cs", `
-            "$PSScriptRoot\src\NuGet.Services.Licenses\Properties\AssemblyInfo.g.cs"
+            "$PSScriptRoot\src\NuGet.Services.Incidents\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.KeyVault\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Licenses\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Logging\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Messaging.Email\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Messaging\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Owin\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.ServiceBus\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Sql\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Status.Table\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Status\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Storage\Properties\AssemblyInfo.g.cs",`
+            "$PSScriptRoot\src\NuGet.Services.Validation.Issues\Properties\AssemblyInfo.g.cs", `
+            "$PSScriptRoot\src\NuGet.Services.Validation\Properties\AssemblyInfo.g.cs"
             
         $versionMetadata | ForEach-Object {
-            Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA
+            Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA -AssemblyVersion "2.0.0.0"
         }
     } `
     -ev +BuildErrors
@@ -130,7 +130,7 @@ Invoke-BuildStep 'Creating artifacts' { `
             "src\NuGet.Services.Licenses\NuGet.Services.Licenses.csproj"
             
         $projects | ForEach-Object {
-            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId
+            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId
         }
     } `
     -ev +BuildErrors

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -863,7 +863,8 @@ Function Set-VersionInfo {
         [string]$Path,
         [string]$Version,
         [string]$Branch,
-        [string]$Commit
+        [string]$Commit,
+        [string]$AssemblyVersion = $null
     )
     
     if (-not $Version) {
@@ -890,10 +891,13 @@ Function Set-VersionInfo {
         $Branch = git rev-parse --abbrev-ref HEAD
     }
     
-    $BuildDateUtc = [DateTimeOffset]::UtcNow	
+    $BuildDateUtc = [DateTimeOffset]::UtcNow
+    if (!$AssemblyVersion) {
+        $AssemblyVersion = $Version
+    }
     $SemanticVersion = $Version + "-" + $Branch
         
-    Trace-Log ("[assembly: AssemblyVersion(""" + $Version + """)]")
+    Trace-Log ("[assembly: AssemblyVersion(""" + $AssemblyVersion + """)]")
     Trace-Log ("[assembly: AssemblyInformationalVersion(""" + $SemanticVersion + """)]")
     Trace-Log ("[assembly: AssemblyMetadata(""Branch"", """ + $Branch + """)]")
     Trace-Log ("[assembly: AssemblyMetadata(""CommitId"", """ + $Commit + """)]")
@@ -908,7 +912,7 @@ Function Set-VersionInfo {
     Add-Content $Path ("using System.Runtime.CompilerServices;")
     Add-Content $Path ("using System.Runtime.InteropServices;")
     
-    Add-Content $Path ("`r`n[assembly: AssemblyVersion(""" + $Version + """)]")
+    Add-Content $Path ("`r`n[assembly: AssemblyVersion(""" + $AssemblyVersion + """)]")
     Add-Content $Path ("[assembly: AssemblyInformationalVersion(""" + $SemanticVersion + """)]")
     Add-Content $Path "#if !PORTABLE"
     Add-Content $Path ("[assembly: AssemblyMetadata(""Branch"", """ + $Branch + """)]")

--- a/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
+++ b/src/NuGet.Services.AzureManagement/NuGet.Services.AzureManagement.csproj
@@ -56,6 +56,7 @@
     <Compile Include="IAzureManagementAPIWrapper.cs" />
     <Compile Include="IAzureManagementAPIWrapperConfiguration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.FeatureFlags/NuGet.Services.FeatureFlags.csproj
+++ b/src/NuGet.Services.FeatureFlags/NuGet.Services.FeatureFlags.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Models\FeatureStatus.cs" />
     <Compile Include="Models\Flight.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.Incidents/NuGet.Services.Incidents.csproj
+++ b/src/NuGet.Services.Incidents/NuGet.Services.Incidents.csproj
@@ -57,6 +57,7 @@
     <Compile Include="IncidentList.cs" />
     <Compile Include="IncidentStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">

--- a/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
+++ b/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Internal\PlainTextRenderer.cs" />
     <Compile Include="MarkdownEmailBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.Messaging\NuGet.Services.Messaging.csproj">

--- a/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
+++ b/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
@@ -50,6 +50,7 @@
     <Compile Include="IEmailMessageEnqueuer.cs" />
     <Compile Include="IServiceBusMessageSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="ServiceBusMessageSerializer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Status.Table/NuGet.Services.Status.Table.csproj
+++ b/src/NuGet.Services.Status.Table/NuGet.Services.Status.Table.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MessageEntity.cs" />
     <Compile Include="MessageType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Status/NuGet.Services.Status.csproj
+++ b/src/NuGet.Services.Status/NuGet.Services.Status.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Message.cs" />
     <Compile Include="ActivePassiveComponent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="ReadOnlyComponentWrapper.cs" />
     <Compile Include="ServiceStatus.cs" />
     <Compile Include="ComponentWrapper.cs" />


### PR DESCRIPTION
This is to reduce binding redirect pain. We take a similar approach on our other common packages.

I also stopped making .symbols.nupkg for our packages. AFAIK none of us have ever used them. It increases build time, artifact sizes, and signing times. If anyone has objections, I can add it back in.