### PR TITLE
Add default NoWarn to nuget.exe package since this is used for job packages

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -670,7 +670,8 @@ Function New-Package {
         [string]$MSBuildVersion = $DefaultMSBuildVersion,
         [switch]$Symbols,
         [string]$Branch,
-        [switch]$IncludeReferencedProjects
+        [switch]$IncludeReferencedProjects,
+        [string[]]$NoWarn = @("NU5100", "NU5110", "NU5111", "NU5128")
     )
     Trace-Log "Creating package from @""$TargetFilePath"""
     $opts = , 'pack'
@@ -695,6 +696,9 @@ Function New-Package {
     }
     if ($PackageId) {
         $Properties += ";PackageId=$PackageId"
+    }
+    if ($NoWarn) {
+        $Properties += ";NoWarn=" + ($NoWarn -join ",")
     }
     $opts += '-Properties', $Properties
     


### PR DESCRIPTION
Job packages are not really dependency packages per se. They are the shape that Octopus wants.
This significantly reduces CI log noise.