### PR TITLE
Bump assembly version up to 3.0.0.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -85,7 +85,7 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\NuGet.Services.Validation\Properties\AssemblyInfo.g.cs"
             
         $versionMetadata | ForEach-Object {
-            Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA -AssemblyVersion "2.0.0.0"
+            Set-VersionInfo -Path $_ -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA -AssemblyVersion "3.0.0.0"
         }
     } `
     -ev +BuildErrors


### PR DESCRIPTION
We cannot easily use 2.0.0.0 since MSBuild rejects binding to a lower assembly version (2.72.0.0 -> 2.0.0.0), even when I added a binding redirect, which is weird.