### PR TITLE
Move KnownOperationNameEnricher to a common place

### DIFF
--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -55,6 +55,7 @@
     <Compile Include="TelemetryInitializers\DeploymentLabelEnricher.cs" />
     <Compile Include="DurationMetric.cs" />
     <Compile Include="TelemetryInitializers\JobPropertiesTelemetryInitializer.cs" />
+    <Compile Include="TelemetryInitializers\KnownOperationNameEnricher.cs" />
     <Compile Include="TelemetryInitializers\MachineNameTelemetryInitializer.cs" />
     <Compile Include="TelemetryProcessors\ExceptionTelemetryProcessor.cs" />
     <Compile Include="Extensions\DiagnosticsTelemetryModuleExtensions.cs" />

--- a/src/NuGet.Services.Logging/TelemetryInitializers/KnownOperationNameEnricher.cs
+++ b/src/NuGet.Services.Logging/TelemetryInitializers/KnownOperationNameEnricher.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace NuGet.Services.Logging
+{
+    /// <summary>
+    /// Because we have web.config based redirects and other steps in the pipeline that act before ASP.NET determines
+    /// the controller and action that a URL is associated with, the "operation name" field has an extremely high
+    /// cardinality which makes it inappropriate as a dimension in some metric systems. For example, sometimes the
+    /// operation name is the verbatim URL path, with parameters filled in. Therefore, we have a list of known operation
+    /// names that we copy to another field, which is better for aggregation.
+    /// </summary>
+    public class KnownOperationNameEnricher : ITelemetryInitializer
+    {
+        private const string KnownOperation = "KnownOperation";
+        private readonly HashSet<string> _knownOperations;
+
+        public KnownOperationNameEnricher(IEnumerable<string> knownOperations)
+        {
+            if (knownOperations == null)
+            {
+                throw new ArgumentNullException(nameof(knownOperations));
+            }
+
+            _knownOperations = new HashSet<string>(knownOperations);
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            var request = telemetry as RequestTelemetry;
+            if (request == null)
+            {
+                return;
+            }
+
+            var itemTelemetry = telemetry as ISupportProperties;
+            if (itemTelemetry == null)
+            {
+                return;
+            }
+
+            var operationName = telemetry.Context?.Operation?.Name;
+            if (operationName == null)
+            {
+                return;
+            }
+
+            if (_knownOperations.Contains(operationName))
+            {
+                itemTelemetry.Properties[KnownOperation] = operationName;
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
+++ b/tests/NuGet.Services.Logging.Tests/NuGet.Services.Logging.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="RequestTelemetryProcessorTests.cs" />
     <Compile Include="Extensions\TelemetryClientExtensionsTests.cs" />
     <Compile Include="TelemetryInitializers\JobPropertiesTelemetryInitializerTests.cs" />
+    <Compile Include="TelemetryInitializers\KnownOperationNameEnricherFacts.cs" />
     <Compile Include="TestableTelemetry.cs" />
     <Compile Include="TelemetryProcessorTest.cs" />
   </ItemGroup>

--- a/tests/NuGet.Services.Logging.Tests/TelemetryInitializers/KnownOperationNameEnricherFacts.cs
+++ b/tests/NuGet.Services.Logging.Tests/TelemetryInitializers/KnownOperationNameEnricherFacts.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Xunit;
+
+namespace NuGet.Services.Logging.Tests
+{
+    public class KnownOperationNameEnricherFacts
+    {
+        public KnownOperationNameEnricherFacts()
+        {
+            KnownOperations = new List<string>();
+            KnownOperations.Add("SomeOperation");
+        }
+
+        public List<string> KnownOperations { get; }
+        public KnownOperationNameEnricher Target => new KnownOperationNameEnricher(KnownOperations);
+
+        [Theory]
+        [InlineData(typeof(DependencyTelemetry))]
+        [InlineData(typeof(EventTelemetry))]
+        [InlineData(typeof(ExceptionTelemetry))]
+        [InlineData(typeof(MetricTelemetry))]
+        [InlineData(typeof(TraceTelemetry))]
+        public void IgnoresNonRequestTelemetry(Type type)
+        {
+            var telemetry = (ITelemetry)Activator.CreateInstance(type);
+            telemetry.Context.Operation.Name = KnownOperations.First();
+
+            Target.Initialize(telemetry);
+
+            Assert.Empty(((ISupportProperties)telemetry).Properties);
+        }
+
+        [Fact]
+        public void AddKnownOperationPropertyToRequestTelemetry()
+        {
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.Operation.Name = "SomeOperation";
+
+            Target.Initialize(telemetry);
+
+            var property = Assert.Single(telemetry.Properties);
+            Assert.Equal("KnownOperation", property.Key);
+            Assert.Equal("SomeOperation", property.Value);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("IgnoreMe")]
+        public void IgnoresTelemetryWithUnknownOperationName(string name)
+        {
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.Operation.Name = name;
+
+            Target.Initialize(telemetry);
+
+            Assert.Empty(telemetry.Properties);
+        }
+    }
+}


### PR DESCRIPTION
This is moved from [NuGetGallery](https://github.com/NuGet/NuGetGallery/blob/2aaa5ce7f9be3b59ba2abff7f8295e4153d1e828/src/NuGetGallery/Telemetry/KnownOperationNameEnricher.cs) and made more general purpose.

This will be used in the search service.