### PR TITLE
Add stream support for service bus BrokeredMessage

### DIFF
--- a/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/IBrokeredMessage.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.ServiceBus
         Task CompleteAsync();
         Task AbandonAsync();
         string GetBody();
+        Stream GetBody<Stream>();
         IBrokeredMessage Clone();
     }
 }

--- a/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/BrokeredMessageWrapper.cs
@@ -50,6 +50,11 @@ namespace NuGet.Services.ServiceBus
             return BrokeredMessage.GetBody<string>();
         }
 
+        public Stream GetBody<Stream>()
+        {
+            return BrokeredMessage.GetBody<Stream>();
+        }
+
         public Task CompleteAsync()
         {
             return BrokeredMessage.CompleteAsync();


### PR DESCRIPTION
The brokered message `string GetBody()` method expects that the message was serialized with  `System.Runtime.Serialization.DataContractSerializer` with a binary `System.Xml.XmlDictionaryReader`. This does not work for secret expiration, since the azure event grid puts message into the subscription and not necessarily with the same serializer contract. It makes sense to provide a way to stream the message from BrokeredMessage directly into bytes and the client can decide to deserialize it as required.