### PR TITLE
Allow jobs and services to flush telemetry 

### DIFF
--- a/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
+++ b/src/NuGet.Services.Contracts/Logging/ITelemetryClient.cs
@@ -23,5 +23,7 @@ namespace NuGet.Services.Logging
             Exception exception,
             IDictionary<string, string> properties = null,
             IDictionary<string, double> metrics = null);
+
+        void Flush();
     }
 }

--- a/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
+++ b/src/NuGet.Services.Logging/TelemetryClientWrapper.cs
@@ -77,5 +77,7 @@ namespace NuGet.Services.Logging
                 // logging failed, don't allow exception to escape
             }
         }
+
+        public void Flush() => _telemetryClient.Flush();
     }
 }


### PR DESCRIPTION
Application Insights SDK buffers telemetry for up to 30 seconds (see [this](https://devblogs.microsoft.com/premier-developer/application-insights-use-case-for-telemetryclient-flush-calls/)). In https://github.com/NuGet/Engineering/issues/3270, I updated the symbol ingester job to forcefully restart if the job reached a non-recoverable state. Today, the job doesn't flush upon restarting, which causes up to 30 seconds of telemetry to be lost.