### PR TITLE
Update Orchestrator message serialization libraries

### DIFF
--- a/src/NuGet.Services.Validation/CheckValidationSetData.cs
+++ b/src/NuGet.Services.Validation/CheckValidationSetData.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.Validation
+{
+    /// <summary>
+    /// The message to check an entire validation set.
+    /// </summary>
+    public class CheckValidationSetData
+    {
+        public CheckValidationSetData(Guid validationTrackingId, bool extendExpiration)
+        {
+            if (validationTrackingId == Guid.Empty)
+            {
+                throw new ArgumentOutOfRangeException(nameof(validationTrackingId));
+            }
+
+            ValidationTrackingId = validationTrackingId;
+            ExtendExpiration = extendExpiration;
+        }
+
+        public Guid ValidationTrackingId { get; set; }
+        public bool ExtendExpiration { get; set; }
+    }
+}

--- a/src/NuGet.Services.Validation/CheckValidatorData.cs
+++ b/src/NuGet.Services.Validation/CheckValidatorData.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace NuGet.Services.Validation
 {
+    /// <summary>
+    /// The message to check a single validation step.
+    /// </summary>
     public class CheckValidatorData
     {
         public CheckValidatorData(Guid validationId)

--- a/src/NuGet.Services.Validation/PackageValidationMessageData.cs
+++ b/src/NuGet.Services.Validation/PackageValidationMessageData.cs
@@ -2,11 +2,31 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Newtonsoft.Json.Linq;
 
 namespace NuGet.Services.Validation
 {
     public class PackageValidationMessageData
     {
+        public static PackageValidationMessageData NewStartValidation(
+            Guid validationTrackingId,
+            string contentType,
+            Uri contentUrl,
+            JObject properties)
+        {
+            return new PackageValidationMessageData(
+                PackageValidationMessageType.StartValidation,
+                startValidation: new StartValidationData(
+                    validationTrackingId,
+                    contentType,
+                    contentUrl,
+                    properties),
+                processValidationSet: null,
+                checkValidationSet: null,
+                checkValidator: null,
+                deliveryCount: 0);
+        }
+
         public static PackageValidationMessageData NewProcessValidationSet(
             string packageId,
             string packageVersion,
@@ -16,12 +36,25 @@ namespace NuGet.Services.Validation
         {
             return new PackageValidationMessageData(
                 PackageValidationMessageType.ProcessValidationSet,
+                startValidation: null,
                 processValidationSet: new ProcessValidationSetData(
                     packageId,
                     packageVersion,
                     validationTrackingId,
                     validatingType,
                     entityKey),
+                checkValidationSet: null,
+                checkValidator: null,
+                deliveryCount: 0);
+        }
+
+        public static PackageValidationMessageData NewCheckValidationSet(Guid validationTrackingId, bool extendExpiration)
+        {
+            return new PackageValidationMessageData(
+                PackageValidationMessageType.CheckValidationSet,
+                startValidation: null,
+                processValidationSet: null,
+                checkValidationSet: new CheckValidationSetData(validationTrackingId, extendExpiration),
                 checkValidator: null,
                 deliveryCount: 0);
         }
@@ -30,23 +63,39 @@ namespace NuGet.Services.Validation
         {
             return new PackageValidationMessageData(
                 PackageValidationMessageType.CheckValidator,
+                startValidation: null,
                 processValidationSet: null,
+                checkValidationSet: null,
                 checkValidator: new CheckValidatorData(validationId),
                 deliveryCount: 0);
         }
 
         internal PackageValidationMessageData(
             PackageValidationMessageType type,
+            StartValidationData startValidation,
             ProcessValidationSetData processValidationSet,
+            CheckValidationSetData checkValidationSet,
             CheckValidatorData checkValidator,
             int deliveryCount)
         {
             switch (type)
             {
+                case PackageValidationMessageType.StartValidation:
+                    if (startValidation == null)
+                    {
+                        throw new ArgumentNullException(nameof(startValidation));
+                    }
+                    break;
                 case PackageValidationMessageType.ProcessValidationSet:
                     if (processValidationSet == null)
                     {
                         throw new ArgumentNullException(nameof(processValidationSet));
+                    }
+                    break;
+                case PackageValidationMessageType.CheckValidationSet:
+                    if (checkValidationSet == null)
+                    {
+                        throw new ArgumentNullException(nameof(checkValidationSet));
                     }
                     break;
                 case PackageValidationMessageType.CheckValidator:
@@ -60,7 +109,9 @@ namespace NuGet.Services.Validation
             }
 
             var notNullCount = 0;
+            notNullCount += startValidation != null ? 1 : 0;
             notNullCount += processValidationSet != null ? 1 : 0;
+            notNullCount += checkValidationSet != null ? 1 : 0;
             notNullCount += checkValidator != null ? 1 : 0;
             if (notNullCount > 1)
             {
@@ -68,13 +119,17 @@ namespace NuGet.Services.Validation
             }
 
             Type = type;
+            StartValidation = startValidation;
             ProcessValidationSet = processValidationSet;
+            CheckValidationSet = checkValidationSet;
             CheckValidator = checkValidator;
             DeliveryCount = deliveryCount;
         }
 
         public PackageValidationMessageType Type { get; }
+        public StartValidationData StartValidation { get; }
         public ProcessValidationSetData ProcessValidationSet { get; }
+        public CheckValidationSetData CheckValidationSet { get; }
         public CheckValidatorData CheckValidator { get; }
         public int DeliveryCount { get; }
     }

--- a/src/NuGet.Services.Validation/PackageValidationMessageType.cs
+++ b/src/NuGet.Services.Validation/PackageValidationMessageType.cs
@@ -5,7 +5,9 @@ namespace NuGet.Services.Validation
 {
     public enum PackageValidationMessageType
     {
+        StartValidation,
         ProcessValidationSet,
+        CheckValidationSet,
         CheckValidator,
     }
 }

--- a/src/NuGet.Services.Validation/ProcessValidationSetData.cs
+++ b/src/NuGet.Services.Validation/ProcessValidationSetData.cs
@@ -6,6 +6,9 @@ using NuGet.Versioning;
 
 namespace NuGet.Services.Validation
 {
+    /// <summary>
+    /// The message to process a validation set for NuGet or symbols package.
+    /// </summary>
     public class ProcessValidationSetData
     {
         public ProcessValidationSetData(

--- a/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
+++ b/src/NuGet.Services.Validation/ServiceBusMessageSerializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Newtonsoft.Json.Linq;
 using NuGet.Services.ServiceBus;
 
 namespace NuGet.Services.Validation
@@ -11,13 +12,26 @@ namespace NuGet.Services.Validation
         private const string ProcessValidationSetSchemaName = "PackageValidationMessageData";
         private const string CheckValidatorSchemaName = "PackageValidationCheckValidatorMessageData";
 
+        private const string StartValidationSchemaName = "StartValidation";
+        private const string CheckValidationSetSchemaName = "CheckValidationSet";
+
+        private static readonly BrokeredMessageSerializer<StartValidationData1> _startValidationSerializer = new BrokeredMessageSerializer<StartValidationData1>();
         private static readonly BrokeredMessageSerializer<ProcessValidationSetData1> _processValidationSetSerializer = new BrokeredMessageSerializer<ProcessValidationSetData1>();
+        private static readonly BrokeredMessageSerializer<CheckValidationSetData1> _checkValidationSetSerializer = new BrokeredMessageSerializer<CheckValidationSetData1>();
         private static readonly BrokeredMessageSerializer<CheckValidatorData1> _checkValidatorSerializer = new BrokeredMessageSerializer<CheckValidatorData1>();
 
         public IBrokeredMessage SerializePackageValidationMessageData(PackageValidationMessageData message)
         {
             switch (message.Type)
             {
+                case PackageValidationMessageType.StartValidation:
+                    return _startValidationSerializer.Serialize(new StartValidationData1
+                    {
+                        ValidationTrackingId = message.StartValidation.ValidationTrackingId,
+                        ContentType = message.StartValidation.ContentType,
+                        ContentUrl = message.StartValidation.ContentUrl,
+                        Properties = message.StartValidation.Properties,
+                    });
                 case PackageValidationMessageType.ProcessValidationSet:
                     return _processValidationSetSerializer.Serialize(new ProcessValidationSetData1
                     {
@@ -27,6 +41,12 @@ namespace NuGet.Services.Validation
                         ValidationTrackingId = message.ProcessValidationSet.ValidationTrackingId,
                         ValidatingType = message.ProcessValidationSet.ValidatingType,
                         EntityKey = message.ProcessValidationSet.EntityKey,
+                    });
+                case PackageValidationMessageType.CheckValidationSet:
+                    return _checkValidationSetSerializer.Serialize(new CheckValidationSetData1
+                    {
+                        ValidationTrackingId = message.CheckValidationSet.ValidationTrackingId,
+                        ExtendExpiration = message.CheckValidationSet.ExtendExpiration,
                     });
                 case PackageValidationMessageType.CheckValidator:
                     return _checkValidatorSerializer.Serialize(new CheckValidatorData1
@@ -43,28 +63,65 @@ namespace NuGet.Services.Validation
             var schemaName = message.GetSchemaName();
             switch (schemaName)
             {
+                case StartValidationSchemaName:
+                    var startValidation = _startValidationSerializer.Deserialize(message);
+                    return new PackageValidationMessageData(
+                        PackageValidationMessageType.StartValidation,
+                        startValidation: new StartValidationData(
+                            startValidation.ValidationTrackingId,
+                            startValidation.ContentType,
+                            startValidation.ContentUrl,
+                            startValidation.Properties),
+                        processValidationSet: null,
+                        checkValidationSet: null,
+                        checkValidator: null,
+                        deliveryCount: message.DeliveryCount);
                 case ProcessValidationSetSchemaName:
                     var processValidationSet = _processValidationSetSerializer.Deserialize(message);
                     return new PackageValidationMessageData(
                         PackageValidationMessageType.ProcessValidationSet,
+                        startValidation: null,
                         processValidationSet: new ProcessValidationSetData(
                             processValidationSet.PackageId,
                             processValidationSet.PackageVersion,
                             processValidationSet.ValidationTrackingId,
                             processValidationSet.ValidatingType,
                             processValidationSet.EntityKey),
+                        checkValidationSet: null,
+                        checkValidator: null,
+                        deliveryCount: message.DeliveryCount);
+                case CheckValidationSetSchemaName:
+                    var checkValidationSet = _checkValidationSetSerializer.Deserialize(message);
+                    return new PackageValidationMessageData(
+                        PackageValidationMessageType.CheckValidationSet,
+                        startValidation: null,
+                        processValidationSet: null,
+                        checkValidationSet: new CheckValidationSetData(
+                            checkValidationSet.ValidationTrackingId,
+                            checkValidationSet.ExtendExpiration),
                         checkValidator: null,
                         deliveryCount: message.DeliveryCount);
                 case CheckValidatorSchemaName:
                     var checkValidator = _checkValidatorSerializer.Deserialize(message);
                     return new PackageValidationMessageData(
                         PackageValidationMessageType.CheckValidator,
+                        startValidation: null,
                         processValidationSet: null,
+                        checkValidationSet: null,
                         checkValidator: new CheckValidatorData(checkValidator.ValidationId),
                         deliveryCount: message.DeliveryCount);
                 default:
                     throw new FormatException($"The provided schema name '{schemaName}' is not supported.");
             }
+        }
+
+        [Schema(Name = StartValidationSchemaName, Version = 1)]
+        private class StartValidationData1
+        {
+            public Guid ValidationTrackingId { get; set; }
+            public string ContentType { get; set; }
+            public Uri ContentUrl { get; set; }
+            public JObject Properties { get; set; }
         }
 
         [Schema(Name = ProcessValidationSetSchemaName, Version = 1)]
@@ -76,6 +133,13 @@ namespace NuGet.Services.Validation
             public Guid ValidationTrackingId { get; set; }
             public ValidatingType ValidatingType { get; set; }
             public int? EntityKey { get; set; }
+        }
+
+        [Schema(Name = CheckValidationSetSchemaName, Version = 1)]
+        private class CheckValidationSetData1
+        {
+            public Guid ValidationTrackingId { get; set; }
+            public bool ExtendExpiration { get; set; }
         }
 
         [Schema(Name = CheckValidatorSchemaName, Version = 1)]

--- a/src/NuGet.Services.Validation/StartValidationData.cs
+++ b/src/NuGet.Services.Validation/StartValidationData.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.Services.Validation
+{
+    /// <summary>
+    /// The message to start a new validation.
+    /// </summary>
+    public class StartValidationData
+    {
+        public StartValidationData(
+            Guid validationTrackingId,
+            string contentType,
+            Uri contentUrl,
+            JObject properties)
+        {
+            if (validationTrackingId == Guid.Empty)
+            {
+                throw new ArgumentOutOfRangeException(nameof(validationTrackingId));
+            }
+
+            if (string.IsNullOrEmpty(contentType))
+            {
+                throw new ArgumentException("The content type property is required", nameof(contentType));
+            }
+
+            ValidationTrackingId = validationTrackingId;
+            ContentType = contentType;
+            ContentUrl = contentUrl ?? throw new ArgumentNullException(nameof(contentUrl));
+            Properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        }
+
+        public Guid ValidationTrackingId { get; set; }
+        public string ContentType { get; set; }
+        public Uri ContentUrl { get; set; }
+        public JObject Properties { get; set; }
+    }
+}

--- a/src/NuGet.Services.Validation/ValidatingType.cs
+++ b/src/NuGet.Services.Validation/ValidatingType.cs
@@ -10,6 +10,6 @@ namespace NuGet.Services.Validation
     public enum ValidatingType
     {
         Package = 0,
-        SymbolPackage = 1
+        SymbolPackage = 1,
     }
 }

--- a/src/NuGet.Services.Validation/ValidatingType.cs
+++ b/src/NuGet.Services.Validation/ValidatingType.cs
@@ -10,6 +10,6 @@ namespace NuGet.Services.Validation
     public enum ValidatingType
     {
         Package = 0,
-        SymbolPackage = 1,
+        SymbolPackage = 1
     }
 }

--- a/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/ServiceBusMessageSerializerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Moq;
+using Newtonsoft.Json.Linq;
 using NuGet.Services.ServiceBus;
 using Xunit;
 
@@ -13,19 +14,51 @@ namespace NuGet.Services.Validation.Tests
     {
         private const string SchemaName = "SchemaName";
         private const string SchemaVersionKey = "SchemaVersion";
+
+        private const string StartValidationType = "StartValidation";
+        private const string ProcessValidationSetType = "PackageValidationMessageData";
+        private const string CheckValidationSetType = "CheckValidationSet";
+        private const string CheckValidatorType = "PackageValidationCheckValidatorMessageData";
+
+        private const int SchemaVersion1 = 1;
+        private const int DeliveryCount = 2;
+
+        private static readonly Guid ValidationTrackingId = new Guid("14b4c1b8-40e2-4d60-9db7-4b7195e807f5");
+        private static readonly Guid ValidationId = new Guid("3fa83d31-3b44-4ffd-bfb8-02a9f5155af6");
+
+        private const int PackageKey = 123;
         private const string PackageId = "NuGet.Versioning";
         private const string PackageVersion = "4.3";
         private const string PackageNormalizedVersion = "4.3.0";
-        private static readonly Guid ValidationTrackingId = new Guid("14b4c1b8-40e2-4d60-9db7-4b7195e807f5");
-        private static readonly Guid ValidationId = new Guid("3fa83d31-3b44-4ffd-bfb8-02a9f5155af6");
-        private const string ProcessValidationSetType = "PackageValidationMessageData";
-        private const string CheckValidatorType = "PackageValidationCheckValidatorMessageData";
-        private const int SchemaVersion1 = 1;
-        private const int DeliveryCount = 2;
-        private const int PackageKey = 123;
+
+        private const string ContentType = "VsCodeExtensionV1";
+        private static readonly Uri ContentUrl = new Uri("https://local.test/my/content");
+        private static readonly JObject Properties = JObject.Parse(@"{ ""Foo"": ""Bar"" }");
 
         public class TheSerializePackageValidationMessageDataMethod : Base
         {
+            [Fact]
+            public void ProducesExpectedMessageForStartValidation()
+            {
+                // Arrange
+                var input = PackageValidationMessageData.NewStartValidation(
+                    ValidationTrackingId,
+                    ContentType,
+                    ContentUrl,
+                    Properties);
+
+                // Act
+                var output = _target.SerializePackageValidationMessageData(input);
+
+                // Assert
+                Assert.Contains(SchemaVersionKey, output.Properties.Keys);
+                Assert.Equal(SchemaVersion1, output.Properties[SchemaVersionKey]);
+                Assert.Contains(SchemaName, output.Properties.Keys);
+                Assert.Equal(StartValidationType, output.Properties[SchemaName]);
+                var body = output.GetBody();
+                Assert.Equal(TestData.SerializedStartValidationData, body);
+            }
+
             [Fact]
             public void ProducesExpectedMessageForCheckValidator()
             {
@@ -68,6 +101,26 @@ namespace NuGet.Services.Validation.Tests
             }
 
             [Fact]
+            public void ProducesExpectedMessageForCheckValidationSet()
+            {
+                // Arrange
+                var input = PackageValidationMessageData.NewCheckValidationSet(
+                    ValidationTrackingId,
+                    extendExpiration: true);
+
+                // Act
+                var output = _target.SerializePackageValidationMessageData(input);
+
+                // Assert
+                Assert.Contains(SchemaVersionKey, output.Properties.Keys);
+                Assert.Equal(SchemaVersion1, output.Properties[SchemaVersionKey]);
+                Assert.Contains(SchemaName, output.Properties.Keys);
+                Assert.Equal(CheckValidationSetType, output.Properties[SchemaName]);
+                var body = output.GetBody();
+                Assert.Equal(TestData.SerializedCheckValidationSetData, body);
+            }
+
+            [Fact]
             public void ProducesExpectedMessageForSymbolsProcessValidationSet()
             {
                 // Arrange
@@ -93,6 +146,28 @@ namespace NuGet.Services.Validation.Tests
 
         public class TheDeserializePackageValidationMessageDataMethod : Base
         {
+            [Fact]
+            public void ProducesExpectedMessageForStartValidation()
+            {
+                // Arrange
+                var brokeredMessage = GetBrokeredMessageForStartValidation();
+
+                // Act
+                var output = _target.DeserializePackageValidationMessageData(brokeredMessage.Object);
+
+                // Assert
+                Assert.Equal(DeliveryCount, output.DeliveryCount);
+                Assert.Equal(PackageValidationMessageType.StartValidation, output.Type);
+                Assert.Equal(ValidationTrackingId, output.StartValidation.ValidationTrackingId);
+                Assert.Equal(ContentType, output.StartValidation.ContentType);
+                Assert.Equal(ContentUrl, output.StartValidation.ContentUrl);
+
+                var property = Assert.Single(output.StartValidation.Properties.Properties());
+                Assert.Equal("Foo", property.Name);
+                Assert.Equal(JTokenType.String, property.Value.Type);
+                Assert.Equal("Bar", property.Value.ToString());
+            }
+
             [Fact]
             public void ProducesExpectedMessageForCheckValidator()
             {
@@ -180,6 +255,22 @@ namespace NuGet.Services.Validation.Tests
                 Assert.Equal(DeliveryCount, output.DeliveryCount);
                 Assert.Equal(ValidatingType.SymbolPackage, output.ProcessValidationSet.ValidatingType);
                 Assert.Equal(expectedKey, output.ProcessValidationSet.EntityKey);
+            }
+
+            [Fact]
+            public void ProducesExpectedMessageForCheckValidationSet()
+            {
+                // Arrange
+                var brokeredMessage = GetBrokeredMessageForCheckValidationSet();
+
+                // Act
+                var output = _target.DeserializePackageValidationMessageData(brokeredMessage.Object);
+
+                // Assert
+                Assert.Equal(DeliveryCount, output.DeliveryCount);
+                Assert.Equal(PackageValidationMessageType.CheckValidationSet, output.Type);
+                Assert.Equal(ValidationTrackingId, output.CheckValidationSet.ValidationTrackingId);
+                Assert.True(output.CheckValidationSet.ExtendExpiration);
             }
 
             [Fact]
@@ -299,6 +390,25 @@ namespace NuGet.Services.Validation.Tests
                 return brokeredMessage;
             }
 
+            private static Mock<IBrokeredMessage> GetBrokeredMessageForStartValidation()
+            {
+                var brokeredMessage = new Mock<IBrokeredMessage>();
+                brokeredMessage
+                    .Setup(x => x.GetBody())
+                    .Returns(TestData.SerializedStartValidationData);
+                brokeredMessage
+                    .Setup(x => x.DeliveryCount)
+                    .Returns(DeliveryCount);
+                brokeredMessage
+                    .Setup(x => x.Properties)
+                    .Returns(new Dictionary<string, object>
+                    {
+                        { SchemaName, StartValidationType },
+                        { SchemaVersionKey, SchemaVersion1 }
+                    });
+                return brokeredMessage;
+            }
+
             private static Mock<IBrokeredMessage> GetBrokeredMessageForCheckValidator()
             {
                 var brokeredMessage = new Mock<IBrokeredMessage>();
@@ -336,6 +446,26 @@ namespace NuGet.Services.Validation.Tests
                     });
                 return brokeredMessage;
             }
+
+            private static Mock<IBrokeredMessage> GetBrokeredMessageForCheckValidationSet()
+            {
+                var brokeredMessage = new Mock<IBrokeredMessage>();
+                brokeredMessage
+                    .Setup(x => x.GetBody())
+                    .Returns(TestData.SerializedCheckValidationSetData);
+                brokeredMessage
+                    .Setup(x => x.DeliveryCount)
+                    .Returns(DeliveryCount);
+                brokeredMessage
+                    .Setup(x => x.Properties)
+                    .Returns(new Dictionary<string, object>
+                    {
+                        { SchemaName, CheckValidationSetType },
+                        { SchemaVersionKey, SchemaVersion1 }
+                    });
+                return brokeredMessage;
+            }
+
         }
 
         public abstract class Base

--- a/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
+++ b/tests/NuGet.Services.Validation.Tests/TestData.Designer.cs
@@ -61,6 +61,15 @@ namespace NuGet.Services.Validation.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ExtendExpiration&quot;:true}.
+        /// </summary>
+        internal static string SerializedCheckValidationSetData {
+            get {
+                return ResourceManager.GetString("SerializedCheckValidationSetData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {&quot;ValidationId&quot;:&quot;3fa83d31-3b44-4ffd-bfb8-02a9f5155af6&quot;}.
         /// </summary>
         internal static string SerializedCheckValidatorData {
@@ -120,6 +129,15 @@ namespace NuGet.Services.Validation.Tests {
         internal static string SerializedProcessValidationSetDataWithNoEntityKey2 {
             get {
                 return ResourceManager.GetString("SerializedProcessValidationSetDataWithNoEntityKey2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {&quot;ValidationTrackingId&quot;:&quot;14b4c1b8-40e2-4d60-9db7-4b7195e807f5&quot;,&quot;ContentType&quot;:&quot;VsCodeExtensionV1&quot;,&quot;ContentUrl&quot;:&quot;https://local.test/my/content&quot;,&quot;Properties&quot;:{&quot;Foo&quot;:&quot;Bar&quot;}}.
+        /// </summary>
+        internal static string SerializedStartValidationData {
+            get {
+                return ResourceManager.GetString("SerializedStartValidationData", resourceCulture);
             }
         }
     }

--- a/tests/NuGet.Services.Validation.Tests/TestData.resx
+++ b/tests/NuGet.Services.Validation.Tests/TestData.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="SerializedCheckValidationSetData" xml:space="preserve">
+    <value>{"ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ExtendExpiration":true}</value>
+  </data>
   <data name="SerializedCheckValidatorData" xml:space="preserve">
     <value>{"ValidationId":"3fa83d31-3b44-4ffd-bfb8-02a9f5155af6"}</value>
   </data>
@@ -137,5 +140,8 @@
   </data>
   <data name="SerializedProcessValidationSetDataWithNoEntityKey2" xml:space="preserve">
     <value>{"PackageId":"NuGet.Versioning","PackageVersion":"4.3","PackageNormalizedVersion":"4.3.0","ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5"}</value>
+  </data>
+  <data name="SerializedStartValidationData" xml:space="preserve">
+    <value>{"ValidationTrackingId":"14b4c1b8-40e2-4d60-9db7-4b7195e807f5","ContentType":"VsCodeExtensionV1","ContentUrl":"https://local.test/my/content","Properties":{"Foo":"Bar"}}</value>
   </data>
 </root>


### PR DESCRIPTION
Create the libraries to serialize and deserialize the new [`StartValidation`](https://github.com/NuGet/Engineering/blob/master/Server.Specs/ValidationProtocol.md#start-validation-message) and [`CheckValidationSet`](https://github.com/NuGet/Engineering/blob/master/Server.Specs/OrchestratorUnifiedValidations.md#checkvalidationset) messages.

Part of https://github.com/NuGet/Engineering/issues/3612

<details>
<summary>Testing...</summary>

Build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4406068&view=results
</details>

/cc @nikhgup