### PR TITLE
Add shared project to unit test Entity Framework

### DIFF
--- a/NuGet.Server.Common.sln
+++ b/NuGet.Server.Common.sln
@@ -93,6 +93,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Services.Licenses.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Services.Build.Tests", "tests\NuGet.Services.Build.Tests\NuGet.Services.Build.Tests.csproj", "{AB3C7814-3AD6-41BD-8968-A3CC10A52EC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Testing.Entities", "src\NuGet.Services.Testing.Entities\NuGet.Services.Testing.Entities.csproj", "{C1D0A112-531C-4ED6-B983-2417335BFB52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,10 @@ Global
 		{AB3C7814-3AD6-41BD-8968-A3CC10A52EC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AB3C7814-3AD6-41BD-8968-A3CC10A52EC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AB3C7814-3AD6-41BD-8968-A3CC10A52EC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1D0A112-531C-4ED6-B983-2417335BFB52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1D0A112-531C-4ED6-B983-2417335BFB52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1D0A112-531C-4ED6-B983-2417335BFB52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1D0A112-531C-4ED6-B983-2417335BFB52}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -299,6 +305,7 @@ Global
 		{20EE3196-4D8B-42B6-8E5E-B8ADC2D3BF9D} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 		{D0A110BD-156D-432B-9525-171430C9F51D} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
 		{AB3C7814-3AD6-41BD-8968-A3CC10A52EC5} = {7783A106-0F4C-4055-9AB4-413FB2C7B8F0}
+		{C1D0A112-531C-4ED6-B983-2417335BFB52} = {8415FED7-1BED-4227-8B4F-BB7C24E041CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AA413DB0-5475-4B5D-A3AF-6323DA8D538B}

--- a/build.ps1
+++ b/build.ps1
@@ -81,6 +81,7 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\NuGet.Services.Status.Table\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Status\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Storage\Properties\AssemblyInfo.g.cs",`
+            "$PSScriptRoot\src\NuGet.Services.Testing.Entities\Properties\AssemblyInfo.g.cs",`
             "$PSScriptRoot\src\NuGet.Services.Validation.Issues\Properties\AssemblyInfo.g.cs", `
             "$PSScriptRoot\src\NuGet.Services.Validation\Properties\AssemblyInfo.g.cs"
             
@@ -130,8 +131,9 @@ Invoke-BuildStep 'Creating artifacts' { `
             "src\NuGet.Services.Messaging\NuGet.Services.Messaging.csproj",
             "src\NuGet.Services.Messaging.Email\NuGet.Services.Messaging.Email.csproj",
             "src\NuGet.Services.FeatureFlags\NuGet.Services.FeatureFlags.csproj",
-            "src\NuGet.Services.Licenses\NuGet.Services.Licenses.csproj"
-            
+            "src\NuGet.Services.Licenses\NuGet.Services.Licenses.csproj",
+            "src\NuGet.Services.Testing.Entities\NuGet.Services.Testing.Entities.csproj"
+
         $projects | ForEach-Object {
             New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -PackageId $packageId
         }

--- a/src/NuGet.Services.Testing.Entities/IDbSetMockExtensions.cs
+++ b/src/NuGet.Services.Testing.Entities/IDbSetMockExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using Moq;
+using NuGet.Services.Testing.Entities;
+
+namespace System.Data.Entity
+{
+    public static class IDbSetMockExtensions
+    {
+        public static Mock<TDbSet> SetupDbSet<TDbSet, TEntity>(
+            this Mock<TDbSet> dbSet,
+            IEnumerable<TEntity> dataEnumerable)
+          where TDbSet : class, IDbSet<TEntity>
+          where TEntity : class
+        {
+            dbSet = dbSet ?? new Mock<TDbSet>();
+            dataEnumerable = dataEnumerable ?? new TEntity[0];
+
+            var data = dataEnumerable.AsQueryable();
+
+            dbSet
+                .As<IDbAsyncEnumerable<TEntity>>()
+                .Setup(m => m.GetAsyncEnumerator())
+                .Returns(() => new TestDbAsyncEnumerator<TEntity>(data.GetEnumerator()));
+
+            dbSet
+                .As<IQueryable<TEntity>>()
+                .Setup(m => m.Provider)
+                .Returns(() => new TestDbAsyncQueryProvider<TEntity>(data.Provider));
+
+            dbSet
+                .Setup(s => s.Add(It.IsAny<TEntity>()))
+                .Callback<TEntity>(e => data = data.Concat(new[] { e }).AsQueryable());
+
+            dbSet
+                .Setup(s => s.Remove(It.IsAny<TEntity>()))
+                .Callback<TEntity>(e => data = data.Where(d => e != d).AsQueryable());
+
+            dbSet.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(() => data.Expression);
+            dbSet.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(() => data.ElementType);
+            dbSet.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+
+            return dbSet;
+        }
+    }
+}

--- a/src/NuGet.Services.Testing.Entities/IDbSetMockExtensions.cs
+++ b/src/NuGet.Services.Testing.Entities/IDbSetMockExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
+using System.Linq.Expressions;
 using Moq;
 using NuGet.Services.Testing.Entities;
 
@@ -11,6 +12,19 @@ namespace System.Data.Entity
 {
     public static class IDbSetMockExtensions
     {
+        public static void SetupDbSet<TContext, TDbSet, TEntity>(
+            this Mock<TContext> entityContext,
+            Expression<Func<TContext, TDbSet>> dbSetAccessor,
+            Mock<TDbSet> dbSet,
+            IEnumerable<TEntity> dataEnumerable)
+          where TContext : class
+          where TDbSet : class, IDbSet<TEntity>
+          where TEntity : class
+        {
+            dbSet = dbSet.SetupDbSet(dataEnumerable);
+            entityContext.Setup(dbSetAccessor).Returns(dbSet.Object);
+        }
+
         public static Mock<TDbSet> SetupDbSet<TDbSet, TEntity>(
             this Mock<TDbSet> dbSet,
             IEnumerable<TEntity> dataEnumerable)

--- a/src/NuGet.Services.Testing.Entities/IValidationEntitiesContextExtensions.cs
+++ b/src/NuGet.Services.Testing.Entities/IValidationEntitiesContextExtensions.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq.Expressions;
+using Moq;
+
+namespace NuGet.Services.Validation
+{
+    public static class IValidationEntitiesContextExtensions
+    {
+        public static void Mock(
+            this Mock<IValidationEntitiesContext> validationContext,
+            Mock<IDbSet<PackageValidationSet>> packageValidationSetsMock = null,
+            Mock<IDbSet<PackageValidation>> packageValidationsMock = null,
+            Mock<IDbSet<ValidatorStatus>> validatorStatusesMock = null,
+            Mock<IDbSet<PackageSigningState>> packageSigningStatesMock = null,
+            Mock<IDbSet<PackageSignature>> packageSignaturesMock = null,
+            Mock<IDbSet<TrustedTimestamp>> trustedTimestampsMock = null,
+            Mock<IDbSet<EndCertificate>> endCertificatesMock = null,
+            Mock<IDbSet<EndCertificateValidation>> certificateValidationsMock = null,
+            Mock<IDbSet<PackageRevalidation>> packageRevalidationsMock = null,
+            Mock<IDbSet<ParentCertificate>> parentCertificatesMock = null,
+            Mock<IDbSet<CertificateChainLink>> certificateChainLinksMock = null,
+            IEnumerable<PackageValidationSet> packageValidationSets = null,
+            IEnumerable<PackageValidation> packageValidations = null,
+            IEnumerable<ValidatorStatus> validatorStatuses = null,
+            IEnumerable<PackageSigningState> packageSigningStates = null,
+            IEnumerable<PackageSignature> packageSignatures = null,
+            IEnumerable<TrustedTimestamp> trustedTimestamps = null,
+            IEnumerable<EndCertificate> endCertificates = null,
+            IEnumerable<EndCertificateValidation> certificateValidations = null,
+            IEnumerable<PackageRevalidation> packageRevalidations = null,
+            IEnumerable<ParentCertificate> parentCertificates = null,
+            IEnumerable<CertificateChainLink> certificateChainLinks = null)
+        {
+            validationContext.SetupDbSet(c => c.PackageValidationSets, packageValidationSetsMock, packageValidationSets);
+            validationContext.SetupDbSet(c => c.PackageValidations, packageValidationsMock, packageValidations);
+            validationContext.SetupDbSet(c => c.ValidatorStatuses, validatorStatusesMock, validatorStatuses);
+            validationContext.SetupDbSet(c => c.PackageSigningStates, packageSigningStatesMock, packageSigningStates);
+            validationContext.SetupDbSet(c => c.PackageSignatures, packageSignaturesMock, packageSignatures);
+            validationContext.SetupDbSet(c => c.TrustedTimestamps, trustedTimestampsMock, trustedTimestamps);
+            validationContext.SetupDbSet(c => c.EndCertificates, endCertificatesMock, endCertificates);
+            validationContext.SetupDbSet(c => c.CertificateValidations, certificateValidationsMock, certificateValidations);
+            validationContext.SetupDbSet(c => c.PackageRevalidations, packageRevalidationsMock, packageRevalidations);
+            validationContext.SetupDbSet(c => c.ParentCertificates, parentCertificatesMock, parentCertificates);
+            validationContext.SetupDbSet(c => c.CertificateChainLinks, certificateChainLinksMock, certificateChainLinks);
+        }
+
+        private static void SetupDbSet<TContext, TDbSet, TEntity>(
+            this Mock<TContext> validationContext,
+            Expression<Func<TContext, TDbSet>> dbSetAccessor,
+            Mock<TDbSet> dbSet,
+            IEnumerable<TEntity> dataEnumerable)
+          where TContext : class
+          where TDbSet : class, IDbSet<TEntity>
+          where TEntity : class
+        {
+            dbSet = dbSet.SetupDbSet(dataEnumerable);
+            validationContext.Setup(dbSetAccessor).Returns(dbSet.Object);
+        }
+    }
+}

--- a/src/NuGet.Services.Testing.Entities/IValidationEntitiesContextExtensions.cs
+++ b/src/NuGet.Services.Testing.Entities/IValidationEntitiesContextExtensions.cs
@@ -48,18 +48,5 @@ namespace NuGet.Services.Validation
             validationContext.SetupDbSet(c => c.ParentCertificates, parentCertificatesMock, parentCertificates);
             validationContext.SetupDbSet(c => c.CertificateChainLinks, certificateChainLinksMock, certificateChainLinks);
         }
-
-        private static void SetupDbSet<TContext, TDbSet, TEntity>(
-            this Mock<TContext> validationContext,
-            Expression<Func<TContext, TDbSet>> dbSetAccessor,
-            Mock<TDbSet> dbSet,
-            IEnumerable<TEntity> dataEnumerable)
-          where TContext : class
-          where TDbSet : class, IDbSet<TEntity>
-          where TEntity : class
-        {
-            dbSet = dbSet.SetupDbSet(dataEnumerable);
-            validationContext.Setup(dbSetAccessor).Returns(dbSet.Object);
-        }
     }
 }

--- a/src/NuGet.Services.Testing.Entities/NuGet.Services.Testing.Entities.csproj
+++ b/src/NuGet.Services.Testing.Entities/NuGet.Services.Testing.Entities.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <Description>Infrastructure to unit test Entity Framework entities.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.10.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.Validation\NuGet.Services.Validation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NuGet.Services.Testing.Entities/README.md
+++ b/src/NuGet.Services.Testing.Entities/README.md
@@ -1,0 +1,21 @@
+## NuGet.Services.Testing.Entities
+
+**Subsystem: Unit testing ✅**
+
+This library provides infrastructure to unit test Entity Framework entities.
+
+Example usage:
+
+```csharp
+Mock<IValidationEntitiesContext> validationContextMock = ...;
+
+validationContextMock.Mock(
+    packageValidations: new List<PackageValidation>
+    {
+        new PackageValidation { ... }
+    });
+
+var validationContext = validationContextMock.Object;
+
+Assert.Single(validationContext.PackageValidations);
+```

--- a/src/NuGet.Services.Testing.Entities/TestDbAsyncQueryProvider.cs
+++ b/src/NuGet.Services.Testing.Entities/TestDbAsyncQueryProvider.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Testing.Entities
+{
+    // Copied from https://msdn.microsoft.com/en-us/library/dn314429.aspx
+    public class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
+    {
+        private readonly IQueryProvider _inner;
+
+        public TestDbAsyncQueryProvider(IQueryProvider inner)
+        {
+            _inner = inner;
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            return new TestDbAsyncEnumerable<TEntity>(expression);
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            return new TestDbAsyncEnumerable<TElement>(expression);
+        }
+
+        public object Execute(Expression expression)
+        {
+            return _inner.Execute(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            return _inner.Execute<TResult>(expression);
+        }
+
+        public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute(expression));
+        }
+
+        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute<TResult>(expression));
+        }
+    }
+
+    public class TestDbAsyncEnumerable<T> : EnumerableQuery<T>, IDbAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestDbAsyncEnumerable(IEnumerable<T> enumerable)
+            : base(enumerable)
+        { }
+
+        public TestDbAsyncEnumerable(Expression expression)
+            : base(expression)
+        { }
+
+        public IDbAsyncEnumerator<T> GetAsyncEnumerator()
+        {
+            return new TestDbAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
+
+        IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
+        {
+            return GetAsyncEnumerator();
+        }
+
+        IQueryProvider IQueryable.Provider
+        {
+            get { return new TestDbAsyncQueryProvider<T>(this); }
+        }
+    }
+
+    public class TestDbAsyncEnumerator<T> : IDbAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestDbAsyncEnumerator(IEnumerator<T> inner)
+        {
+            _inner = inner;
+        }
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+
+        public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_inner.MoveNext());
+        }
+
+        public T Current
+        {
+            get { return _inner.Current; }
+        }
+
+        object IDbAsyncEnumerator.Current
+        {
+            get { return Current; }
+        }
+    }
+}


### PR DESCRIPTION
NuGet.Jobs facilitates unit testing Entity Framework context in [`Validation.PackageSigning.Helpers`](https://github.com/NuGet/NuGet.Jobs/tree/262da48ed05d0366613bbf1c54f47879aad96dcd/tests/Validation.PackageSigning.Helpers). This change moves these helpers into a new project, `NuGet.Services.Testing.Entities`, so that we can share them across other repositories like NuGetMonitoring and NuGetGallery.

See: https://github.com/NuGet/NuGet.Jobs/pull/960
See: https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetMonitoring/pullrequest/1668

Part of: https://github.com/NuGet/Engineering/issues/3584

Test release: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4446773&view=results