### PR TITLE
adding sync methods for servicebus to be used for marketplace

### DIFF
--- a/src/NuGet.Services.Contracts/ServiceBus/ITopicClient.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/ITopicClient.cs
@@ -8,5 +8,11 @@ namespace NuGet.Services.ServiceBus
     public interface ITopicClient
     {
         Task SendAsync(IBrokeredMessage message);
+
+        void Send(IBrokeredMessage message);
+
+        Task CloseAsync();
+
+        void Close();
     }
 }

--- a/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
@@ -39,41 +39,13 @@ namespace NuGet.Services.ServiceBus
 
         public Task SendAsync(IBrokeredMessage message)
         {
-            // For now, assume the only implementation is the wrapper type. We could clone over all properties
-            // that the interface supports, but this is not necessary right now.
-            var wrapper = message as BrokeredMessageWrapper;
-            BrokeredMessage innerMessage;
-            if (message != null)
-            {
-                innerMessage = wrapper.BrokeredMessage;
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"The message must be of type {typeof(BrokeredMessageWrapper).FullName}.",
-                    nameof(message));
-            }
-
+            BrokeredMessage innerMessage = GetBrokeredMessage(message);
             return _client.SendAsync(innerMessage);
         }
 
         public void Send(IBrokeredMessage message)
         {
-            // For now, assume the only implementation is the wrapper type. We could clone over all properties
-            // that the interface supports, but this is not necessary right now.
-            var wrapper = message as BrokeredMessageWrapper;
-            BrokeredMessage innerMessage;
-            if (message != null)
-            {
-                innerMessage = wrapper.BrokeredMessage;
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"The message must be of type {typeof(BrokeredMessageWrapper).FullName}.",
-                    nameof(message));
-            }
-
+            BrokeredMessage innerMessage = GetBrokeredMessage(message);
             _client.Send(innerMessage);
         }
 
@@ -85,6 +57,25 @@ namespace NuGet.Services.ServiceBus
         public Task Close()
         {
             return _client.CloseAsync();
+        }
+
+        private BrokeredMessage GetBrokeredMessage(IBrokeredMessage message)
+        {
+            // For now, assume the only implementation is the wrapper type. We could clone over all properties
+            // that the interface supports, but this is not necessary right now.
+            var wrapper = message as BrokeredMessageWrapper;
+            BrokeredMessage innerMessage;
+            if (message != null)
+            {
+                innerMessage = wrapper.BrokeredMessage;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"The message must be of type {typeof(BrokeredMessageWrapper).FullName}.",
+                    nameof(message));
+            }
+            return innerMessage;
         }
     }
 }

--- a/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
@@ -39,24 +39,24 @@ namespace NuGet.Services.ServiceBus
 
         public Task SendAsync(IBrokeredMessage message)
         {
-            BrokeredMessage innerMessage = GetBrokeredMessage(message);
+            var innerMessage = GetBrokeredMessage(message);
             return _client.SendAsync(innerMessage);
         }
 
         public void Send(IBrokeredMessage message)
         {
-            BrokeredMessage innerMessage = GetBrokeredMessage(message);
+            var innerMessage = GetBrokeredMessage(message);
             _client.Send(innerMessage);
         }
 
-        public void CloseSync()
+        public void Close()
         {
             _client.Close();
         }
 
-        public Task Close()
+        public async Task CloseAsync()
         {
-            return _client.CloseAsync();
+            await _client.CloseAsync();
         }
 
         private BrokeredMessage GetBrokeredMessage(IBrokeredMessage message)
@@ -75,6 +75,7 @@ namespace NuGet.Services.ServiceBus
                     $"The message must be of type {typeof(BrokeredMessageWrapper).FullName}.",
                     nameof(message));
             }
+
             return innerMessage;
         }
     }

--- a/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/TopicClientWrapper.cs
@@ -57,6 +57,31 @@ namespace NuGet.Services.ServiceBus
             return _client.SendAsync(innerMessage);
         }
 
+        public void Send(IBrokeredMessage message)
+        {
+            // For now, assume the only implementation is the wrapper type. We could clone over all properties
+            // that the interface supports, but this is not necessary right now.
+            var wrapper = message as BrokeredMessageWrapper;
+            BrokeredMessage innerMessage;
+            if (message != null)
+            {
+                innerMessage = wrapper.BrokeredMessage;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"The message must be of type {typeof(BrokeredMessageWrapper).FullName}.",
+                    nameof(message));
+            }
+
+            _client.Send(innerMessage);
+        }
+
+        public void CloseSync()
+        {
+            _client.Close();
+        }
+
         public Task Close()
         {
             return _client.CloseAsync();


### PR DESCRIPTION
Marketplace job agents are synchronous. Adding async support would be a large undertaking, so instead, we will use synchronous methods to send Service Bus messages.