### PR TITLE
Storage factory in FeatureFlagCacheService

### DIFF
--- a/src/NuGet.Services.FeatureFlags/FeatureFlagCacheService.cs
+++ b/src/NuGet.Services.FeatureFlags/FeatureFlagCacheService.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.FeatureFlags
 {
     public class FeatureFlagCacheService : IFeatureFlagCacheService
     {
-        private readonly IFeatureFlagStorageService _storage;
+        private readonly Func<IFeatureFlagStorageService> _storageFactory;
         private readonly FeatureFlagOptions _options;
         private readonly IFeatureFlagTelemetryService _telemetryServiceOrNull;
         private readonly ILogger<FeatureFlagCacheService> _logger;
@@ -18,20 +18,20 @@ namespace NuGet.Services.FeatureFlags
         private FeatureFlagsAndRefreshTime _latestFlags;
 
         public FeatureFlagCacheService(
-            IFeatureFlagStorageService storage,
+            Func<IFeatureFlagStorageService> storageFactory,
             FeatureFlagOptions options,
             ILogger<FeatureFlagCacheService> logger)
-          : this(storage, options, telemetryService: null, logger: logger)
+          : this(storageFactory, options, telemetryService: null, logger: logger)
         {
         }
 
         public FeatureFlagCacheService(
-            IFeatureFlagStorageService storage,
+            Func<IFeatureFlagStorageService> storageFactory,
             FeatureFlagOptions options,
             IFeatureFlagTelemetryService telemetryService,
             ILogger<FeatureFlagCacheService> logger)
         {
-            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            _storageFactory = storageFactory ?? throw new ArgumentNullException(nameof(storageFactory));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -52,7 +52,7 @@ namespace NuGet.Services.FeatureFlags
         public async Task RefreshAsync()
         {
             var refreshTime = DateTimeOffset.UtcNow;
-            var latestFlags = await _storage.GetAsync();
+            var latestFlags = await _storageFactory().GetAsync();
 
             _latestFlags = new FeatureFlagsAndRefreshTime(latestFlags, refreshTime);
         }

--- a/tests/NuGet.Services.FeatureFlags.Tests/FeatureFlagCacheServiceFacts.cs
+++ b/tests/NuGet.Services.FeatureFlags.Tests/FeatureFlagCacheServiceFacts.cs
@@ -127,7 +127,7 @@ namespace NuGet.Services.FeatureFlags.Tests
             {
                 // Arrange
                 var target = new FeatureFlagCacheService(
-                    _storage.Object,
+                    () => _storage.Object,
                     _options,
                     telemetryService: null,
                     logger: Mock.Of<ILogger<FeatureFlagCacheService>>());
@@ -192,7 +192,7 @@ namespace NuGet.Services.FeatureFlags.Tests
                 _options = new FeatureFlagOptions();
 
                 _target = new FeatureFlagCacheService(
-                    _storage.Object,
+                    () => _storage.Object,
                     _options,
                     _telemetry.Object,
                     Mock.Of<ILogger<FeatureFlagCacheService>>());


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3522

`FeatureFlagCacheService` needs to be a singleton in services to maintain cache, but it should not be holding on to an instance of a storage service: it prevents proper secret refresh. The class is modified instead to receive a storage service factory that it uses to produce instances of a storage service as needed.