### PR TITLE
Allow optional JSON config files

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationBuilderExtensions.cs
@@ -15,9 +15,18 @@ namespace NuGet.Services.Configuration
             string path,
             ISecretInjector secretInjector)
         {
+            return configurationBuilder.AddInjectedJsonFile(path, secretInjector, optional: false);
+        }
+
+        public static IConfigurationBuilder AddInjectedJsonFile(
+            this IConfigurationBuilder configurationBuilder,
+            string path,
+            ISecretInjector secretInjector,
+            bool optional)
+        {
             configurationBuilder = configurationBuilder ?? throw new ArgumentNullException(nameof(configurationBuilder));
 
-            configurationBuilder.Add(new KeyVaultJsonInjectingConfigurationSource(path, secretInjector));
+            configurationBuilder.Add(new KeyVaultJsonInjectingConfigurationSource(path, secretInjector, optional));
 
             return configurationBuilder;
         }

--- a/src/NuGet.Services.Configuration/KeyVaultJsonInjectingConfigurationSource.cs
+++ b/src/NuGet.Services.Configuration/KeyVaultJsonInjectingConfigurationSource.cs
@@ -18,16 +18,23 @@ namespace NuGet.Services.Configuration
     {
         private readonly string _path;
         private readonly ISecretInjector _secretInjector;
+        private readonly bool _optional;
 
         public KeyVaultJsonInjectingConfigurationSource(string path, ISecretInjector secretInjector)
+            : this(path, secretInjector, optional: false)
+        {
+        }
+
+        public KeyVaultJsonInjectingConfigurationSource(string path, ISecretInjector secretInjector, bool optional)
         {
             _path = path ?? throw new ArgumentNullException(nameof(path));
             _secretInjector = secretInjector ?? throw new ArgumentNullException(nameof(secretInjector));
+            _optional = optional;
         }
 
         public Extensions.IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            var jsonSource = new JsonConfigurationSource { FileProvider = null, Path = _path, Optional = false, ReloadOnChange = false };
+            var jsonSource = new JsonConfigurationSource { FileProvider = null, Path = _path, Optional = _optional, ReloadOnChange = false };
             jsonSource.ResolveFileProvider();
             var jsonProvider = jsonSource.Build(builder);
 


### PR DESCRIPTION
This will allow environments that expect config to come from environment variables (e.g. App Service app settings) to use the same code as local environments that more easily use JSON config files.