### PR TITLE
Update init.ps1 to clone repository instead of using GH APIs.

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -19,7 +19,7 @@ Function Get-BuildTools {
     }
     Set-Location $ServerCommonRoot
     $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
-    Write-Host "Latest commit in branch $BuildBranch: " $BuildBranchCommit
+    Write-Host "Latest commit in branch $BuildBranch is $BuildBranchCommit"
 
     Function Get-Folder {
         [CmdletBinding()]

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -19,20 +19,20 @@ Function Get-BuildTools {
     }
     Set-Location $ServerCommonRoot
     $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
-    Write-Host "BuildBranchCommit: " $BuildBranchCommit
+    Write-Host "Latest commit in branch $BuildBranch: " $BuildBranchCommit
 
     Function Get-Folder {
         [CmdletBinding()]
         param(
             [string]$Path
         )
-        # Create directory if not exists
+        # Create directory if not exists in root
         $DirectoryPath = (Join-Path $NuGetClientRoot $Path)
         if (-not (Test-Path $DirectoryPath)) {
             New-Item -Path $DirectoryPath -ItemType "directory"
         }
 
-        # Verifies if marker file on the directory is up to date
+        # Verifies if marker file on the directory contains latest commit
         $MarkerFile = Join-Path $DirectoryPath ".marker"
         if (Test-Path $MarkerFile) {
             $content = Get-Content $MarkerFile
@@ -42,7 +42,7 @@ Function Get-BuildTools {
             }
         }
         
-        # Recursively creates the inner folders
+        # Recursively creates the inner directories
         $FolderUri = Join-Path $ServerCommonRoot $Path
         $InnerDirectories = Get-ChildItem -Path $FolderUri -Directory
         foreach ($InnerDirectory in $InnerDirectories)
@@ -51,7 +51,7 @@ Function Get-BuildTools {
             Get-Folder -Path $InnerDirectoryPath
         }
 
-        # Gets all files from current repository directory and moves them to root directory folder
+        # Gets all files from current repository directory and moves them to root directory
         $FileDirectory = Join-Path $NuGetClientRoot $Path
         $FilesToMove = Get-ChildItem -Path $FolderUri -File
         Foreach ($File in $FilesToMove)

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -14,7 +14,7 @@ Function Get-BuildTools {
 
     if (-not (Test-Path $ServerCommonRoot))
     {
-        git clone -b $Branch https://github.com/NuGet/ServerCommon.git
+        git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1
     }
     Set-Location $ServerCommonRoot
     $BranchCommit = git rev-parse "origin/$Branch"

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -14,7 +14,6 @@ Function Get-BuildTools {
 
     if (-not (Test-Path $ServerCommonRoot))
     {
-        git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1
         & cmd /c "git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1"
     }
     Set-Location $ServerCommonRoot

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -15,9 +15,11 @@ Function Get-BuildTools {
     if (-not (Test-Path $ServerCommonRoot))
     {
         git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1
+        & cmd /c "git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1"
     }
     Set-Location $ServerCommonRoot
-    $BranchCommit = git rev-parse "origin/$Branch"
+    $BranchCommit = & cmd /c "git rev-parse 'origin/$Branch'"
+    Write-Host "BranchCommit: " $BranchCommit
 
     Function Get-Folder {
         [CmdletBinding()]

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Branch = 'main'
+    [string]$BuildBranch = 'main'
 )
 
 # This file is downloaded to "build/init.ps1" so use the parent folder as the root
@@ -9,16 +9,17 @@ $ServerCommonRoot = Join-Path $NuGetClientRoot "\ServerCommon";
 
 Function Get-BuildTools {
     param(
-        [string]$Branch
+        [string]$BuildBranch
     )
 
     if (-not (Test-Path $ServerCommonRoot))
     {
-        & cmd /c "git clone -b $Branch https://github.com/NuGet/ServerCommon.git 2>&1"
+        Write-Host "Clonning ServerCommon repository with $BuildBranch branch"
+        & cmd /c "git clone -b $BuildBranch https://github.com/NuGet/ServerCommon.git 2>&1"
     }
     Set-Location $ServerCommonRoot
-    $BranchCommit = & cmd /c "git rev-parse 'origin/$Branch'"
-    Write-Host "BranchCommit: " $BranchCommit
+    $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
+    Write-Host "BuildBranchCommit: " $BuildBranchCommit
 
     Function Get-Folder {
         [CmdletBinding()]
@@ -35,8 +36,8 @@ Function Get-BuildTools {
         $MarkerFile = Join-Path $DirectoryPath ".marker"
         if (Test-Path $MarkerFile) {
             $content = Get-Content $MarkerFile
-            if ($content -eq $BranchCommit) {
-                Write-Host "Build tools directory '$Path' is already at '$Branch'."
+            if ($content -eq $BuildBranchCommit) {
+                Write-Host "Build tools directory '$Path' is already at '$BuildBranchCommit'."
                 return;
             }
         }
@@ -66,7 +67,7 @@ Function Get-BuildTools {
         }
 
         # Creates the marker file for the current directory
-        $BranchCommit | Out-File $MarkerFile
+        $BuildBranchCommit | Out-File $MarkerFile
     }
 
     $FoldersToMove = "build", "tools"
@@ -75,7 +76,7 @@ Function Get-BuildTools {
     }
 }
 
-Get-BuildTools -Branch $Branch
+Get-BuildTools -BuildBranch $BuildBranch
 Set-Location $NuGetClientRoot
 Remove-Item -Path $ServerCommonRoot -Recurse -Force
 

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -1,69 +1,82 @@
 [CmdletBinding()]
 param(
-    [string]$BuildBranch
+    [string]$Branch = 'main'
 )
 
 # This file is downloaded to "build/init.ps1" so use the parent folder as the root
 $NuGetClientRoot = Split-Path -Path $PSScriptRoot -Parent
+$ServerCommonRoot = Join-Path $NuGetClientRoot "\ServerCommon";
 
 Function Get-BuildTools {
     param(
         [string]$Branch
     )
 
-    # Download common.ps1 and other tools used by this build script
-    $RootGitHubApiUri = "https://api.github.com/repos/NuGet/ServerCommon/contents"
-
-    if ($Branch) {
-        $Ref = '?ref=' + $Branch
-    } else {
-        $Ref = ''
+    if (-not (Test-Path $ServerCommonRoot))
+    {
+        git clone -b $Branch https://github.com/NuGet/ServerCommon.git
     }
+    Set-Location $ServerCommonRoot
+    $BranchCommit = git rev-parse "origin/$Branch"
 
     Function Get-Folder {
         [CmdletBinding()]
         param(
             [string]$Path
         )
-        
+        # Create directory if not exists
         $DirectoryPath = (Join-Path $NuGetClientRoot $Path)
         if (-not (Test-Path $DirectoryPath)) {
             New-Item -Path $DirectoryPath -ItemType "directory"
         }
 
+        # Verifies if marker file on the directory is up to date
         $MarkerFile = Join-Path $DirectoryPath ".marker"
         if (Test-Path $MarkerFile) {
             $content = Get-Content $MarkerFile
-            if ($content -eq $Branch) {
+            if ($content -eq $BranchCommit) {
                 Write-Host "Build tools directory '$Path' is already at '$Branch'."
                 return;
             }
         }
         
-        $FolderUri = "$RootGitHubApiUri/$Path$Ref"
-        Write-Host "Downloading files from $FolderUri"
-        $Files = wget -UseBasicParsing $FolderUri | ConvertFrom-Json
-        Foreach ($File in $Files) {
-            $FilePath = $File.path
-            if ($File.type -eq "file") {
-                $DownloadUrl = $File.download_url
-                Write-Host "Downloading file at $DownloadUrl"
-                wget -UseBasicParsing -Uri $DownloadUrl -OutFile (Join-Path $NuGetClientRoot $FilePath)
-            } elseif ($File.type -eq "dir") {
-                Get-Folder -Path $FilePath
+        # Recursively creates the inner folders
+        $FolderUri = Join-Path $ServerCommonRoot $Path
+        $InnerDirectories = Get-ChildItem -Path $FolderUri -Directory
+        foreach ($InnerDirectory in $InnerDirectories)
+        {
+            $InnerDirectoryPath = ($InnerDirectory.FullName).Replace("$ServerCommonRoot", "")
+            Get-Folder -Path $InnerDirectoryPath
+        }
+
+        # Gets all files from current repository directory and moves them to root directory folder
+        $FileDirectory = Join-Path $NuGetClientRoot $Path
+        $FilesToMove = Get-ChildItem -Path $FolderUri -File
+        Foreach ($File in $FilesToMove)
+        {
+            if (-not (Test-Path (Join-Path $FileDirectory $File)))
+            {
+                $File | Move-Item -Destination $FileDirectory
+            }
+            else
+            {
+                Write-Host "File $File Already created"
             }
         }
 
-        $Branch | Out-File $MarkerFile
+        # Creates the marker file for the current directory
+        $BranchCommit | Out-File $MarkerFile
     }
 
-    $FoldersToDownload = "build", "tools"
-    foreach ($Folder in $FoldersToDownload) {
+    $FoldersToMove = "build", "tools"
+    foreach ($Folder in $FoldersToMove) {
         Get-Folder -Path $Folder
     }
 }
 
-Get-BuildTools -Branch $BuildBranch
+Get-BuildTools -Branch $Branch
+Set-Location $NuGetClientRoot
+Remove-Item -Path $ServerCommonRoot -Recurse -Force
 
 # Run common.ps1
 . "$NuGetClientRoot\build\common.ps1"


### PR DESCRIPTION
- init.ps1 was updated to clone a repository instead of using the GitHub content Api. This will allow us to avoid throttle issues.
- Basically it clones the ServerCommon repository and moves the needed files on their respective directories.
- I dropped the usage of the specific commit we were using, I thought it would be better to have only the branch name and the commit used in the script will be the latest on that branch, this will allow us to better test a certain branch when we make changes to ServerCommon scripts.
