### PR TITLE
Add support for PAT for multiple private feeds using Credential Provider

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,9 @@ param (
     [string]$SimpleVersion = '1.0.0',
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
-    [string]$CommitSHA
+    [string]$CommitSHA,
+    [string]$Username,
+    [string]$AccessToken
 )
 
 # For TeamCity - If any issue occurs, this script fails the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail
@@ -51,9 +53,9 @@ Invoke-BuildStep 'Getting private build tools' { Install-PrivateBuildTools } `
 Invoke-BuildStep 'Cleaning test results' { Clean-Tests } `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet } `
+Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet -Username $Username -AccessToken $AccessToken } `
     -ev +BuildErrors
-    
+
 Invoke-BuildStep 'Clearing package cache' { Clear-PackageCache } `
     -skip:(-not $CleanCache) `
     -ev +BuildErrors

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,6 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$Username,
     [string]$AccessToken
 )
 
@@ -53,7 +52,7 @@ Invoke-BuildStep 'Getting private build tools' { Install-PrivateBuildTools } `
 Invoke-BuildStep 'Cleaning test results' { Clean-Tests } `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet -Username $Username -AccessToken $AccessToken } `
+Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet -AccessToken $AccessToken } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Clearing package cache' { Clear-PackageCache } `

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -474,9 +474,11 @@ Function Install-NuGet {
     }
 
     if ($AccessToken) {
-        Write-Host 'Using PAT workflow'
+        Write-Host 'Using AccessToken workflow'
         $endpoints = @()
         $endpointURIs = @()
+
+        Write-Host "First NuGet.Config path: " Join-Path $PSScriptRoot '\nuget.config'
 
         Get-ChildItem "$PSScriptRoot\nuget.config" -Recurse |% {
             $nugetConfig = [xml](Get-Content -Path $_)

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -482,6 +482,8 @@ Function Install-NuGet {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
+                Write-Host "Found feed: " $_.value
+            
                 if ($endpointURIs -notcontains $_.Value) {
                     $endpointURIs += $_.Value;
                     $endpoint = New-Object -TypeName PSObject;

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -478,9 +478,7 @@ Function Install-NuGet {
         $endpoints = @()
         $endpointURIs = @()
 
-        Write-Host "First NuGet.Config path: " Join-Path $PSScriptRoot '\nuget.config'
-
-        Get-ChildItem "$PSScriptRoot\nuget.config" -Recurse |% {
+        Get-ChildItem "..\nuget.config" -Recurse |% {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -474,7 +474,6 @@ Function Install-NuGet {
     }
 
     if ($AccessToken) {
-        Write-Host 'Using AccessToken workflow'
         $endpoints = @()
         $endpointURIs = @()
 
@@ -482,8 +481,6 @@ Function Install-NuGet {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
-                Write-Host "Found feed: " $_.value
-            
                 if ($endpointURIs -notcontains $_.Value) {
                     $endpointURIs += $_.Value;
                     $endpoint = New-Object -TypeName PSObject;
@@ -499,12 +496,7 @@ Function Install-NuGet {
         Add-Member -InputObject $auth -MemberType NoteProperty -Name endpointCredentials -Value $endpoints;
 
         $authJson = ConvertTo-Json -InputObject $auth;
-        Write-Host 'Adding the following private feed endpoints' $authJson
         $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $authJson;
-    }
-    else
-    {
-        Write-Host "No AccessToken is used"
     }
 
     Trace-Log "Setting NuGet .NET Framework credential path"

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -475,20 +475,16 @@ Function Install-NuGet {
 
     if ($AccessToken) {
         $endpoints = @()
-        $endpointURIs = @()
 
         Get-ChildItem "$NuGetClientRoot\nuget.config" -Recurse |% {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
-                if ($endpointURIs -notcontains $_.Value) {
-                    $endpointURIs += $_.Value;
-                    $endpoint = New-Object -TypeName PSObject;
-                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value;
-                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value 'PAT';
-                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken;
-                    $endpoints += $endpoint;
-                }
+                $endpoint = New-Object -TypeName PSObject;
+                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value;
+                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value 'PAT';
+                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken;
+                $endpoints += $endpoint;
             }
         }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -477,7 +477,7 @@ Function Install-NuGet {
         $endpoints = @()
         $endpointURIs = @()
 
-        Get-ChildItem "..\nuget.config" -Recurse |% {
+        Get-ChildItem "$NuGetClientRoot\nuget.config" -Recurse |% {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -474,6 +474,7 @@ Function Install-NuGet {
     }
 
     if ($AccessToken) {
+        Write-Host 'Using PAT workflow'
         $endpoints = @()
         $endpointURIs = @()
 
@@ -496,7 +497,7 @@ Function Install-NuGet {
         Add-Member -InputObject $auth -MemberType NoteProperty -Name endpointCredentials -Value $endpoints;
 
         $authJson = ConvertTo-Json -InputObject $auth;
-        Write-Host $authJson
+        Write-Host 'Adding the following private feed endpoints' $authJson
         $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $authJson;
     }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -500,6 +500,10 @@ Function Install-NuGet {
         Write-Host 'Adding the following private feed endpoints' $authJson
         $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $authJson;
     }
+    else
+    {
+        Write-Host "No AccessToken is used"
+    }
 
     Trace-Log "Setting NuGet .NET Framework credential path"
     $env:NUGET_NETFX_PLUGIN_PATHS = $CredentialProviderPath

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -403,7 +403,6 @@ Function Update-Submodule {
 Function Install-NuGet {
     [CmdletBinding()]
     param(
-        [string]$Username,
         [string]$AccessToken
     )
 
@@ -486,7 +485,7 @@ Function Install-NuGet {
                     $endpointURIs += $_.Value;
                     $endpoint = New-Object -TypeName PSObject;
                     Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value;
-                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value $Username;
+                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value 'PAT';
                     Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken;
                     $endpoints += $endpoint;
                 }
@@ -497,6 +496,7 @@ Function Install-NuGet {
         Add-Member -InputObject $auth -MemberType NoteProperty -Name endpointCredentials -Value $endpoints;
 
         $authJson = ConvertTo-Json -InputObject $auth;
+        Write-Host $authJson
         $env:VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $authJson;
     }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -475,16 +475,20 @@ Function Install-NuGet {
 
     if ($AccessToken) {
         $endpoints = @()
+        $endpointURIs = @()
 
         Get-ChildItem "$NuGetClientRoot\nuget.config" -Recurse |% {
             $nugetConfig = [xml](Get-Content -Path $_)
 
             $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
-                $endpoint = New-Object -TypeName PSObject;
-                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value;
-                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value 'PAT';
-                Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken;
-                $endpoints += $endpoint;
+                if ($endpointURIs -notcontains $_.Value) {
+                    $endpointURIs += $_.Value;
+                    $endpoint = New-Object -TypeName PSObject;
+                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value;
+                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value 'PAT';
+                    Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken;
+                    $endpoints += $endpoint;
+                }
             }
         }
 


### PR DESCRIPTION
This adds multiple private feeds to the env variable `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` that's used by the Credential Provider. This will remove the need to add private feeds one by one.