### PR TITLE
init.ps1 script now clones ServerCommon repository with a specific commit.

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$BuildBranch = 'main'
+    [string]$BuildBranch = 'main',
+    [string]$BuildBranchCommit = $null
 )
 
 # This file is downloaded to "build/init.ps1" so use the parent folder as the root
@@ -14,12 +15,22 @@ Function Get-BuildTools {
 
     if (-not (Test-Path $ServerCommonRoot))
     {
-        Write-Host "Clonning ServerCommon repository with $BuildBranch branch"
-        & cmd /c "git clone -b $BuildBranch https://github.com/NuGet/ServerCommon.git 2>&1"
+        Write-Host "Clonning ServerCommon repository with $BuildBranch branch."
+        & cmd /c "git clone -b $BuildBranch https://github.com/NuGet/ServerCommon.git --depth 1 2>&1"
     }
+
     Set-Location $ServerCommonRoot
-    $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
-    Write-Host "Latest commit in branch $BuildBranch is $BuildBranchCommit"
+    if (!$BuildBranchCommit)
+    {
+        $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
+    }
+    else
+    {
+        & cmd /c "git fetch origin $BuildBranchCommit 2>&1"
+        & cmd /c "git reset --hard FETCH_HEAD 2>&1"
+    }
+
+    Write-Host "ServerCommon repository cloned with branch $BuildBranch and $BuildBranchCommit commit."
 
     Function Get-Folder {
         [CmdletBinding()]

--- a/build/init.ps1
+++ b/build/init.ps1
@@ -1,7 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$BuildBranch = 'main',
-    [string]$BuildBranchCommit = $null
+    [string]$BuildBranchCommit
 )
 
 # This file is downloaded to "build/init.ps1" so use the parent folder as the root
@@ -10,27 +9,13 @@ $ServerCommonRoot = Join-Path $NuGetClientRoot "\ServerCommon";
 
 Function Get-BuildTools {
     param(
-        [string]$BuildBranch
+        [string]$BuildBranchCommit
     )
-
-    if (-not (Test-Path $ServerCommonRoot))
-    {
-        Write-Host "Clonning ServerCommon repository with $BuildBranch branch."
-        & cmd /c "git clone -b $BuildBranch https://github.com/NuGet/ServerCommon.git --depth 1 2>&1"
-    }
-
-    Set-Location $ServerCommonRoot
-    if (!$BuildBranchCommit)
-    {
-        $BuildBranchCommit = & cmd /c "git rev-parse origin/$BuildBranch 2>&1"
-    }
-    else
-    {
-        & cmd /c "git fetch origin $BuildBranchCommit 2>&1"
-        & cmd /c "git reset --hard FETCH_HEAD 2>&1"
-    }
-
-    Write-Host "ServerCommon repository cloned with branch $BuildBranch and $BuildBranchCommit commit."
+    Write-Host "Getting ServerCommon repository..."
+    & cmd /c "git init && git remote add origin https://github.com/NuGet/ServerCommon.git 2>&1"
+    & cmd /c "git fetch origin $BuildBranchCommit 2>&1"
+    & cmd /c "git reset --hard FETCH_HEAD 2>&1"
+    Write-Host "ServerCommon repository retrieved on $BuildBranchCommit commit."
 
     Function Get-Folder {
         [CmdletBinding()]
@@ -87,7 +72,12 @@ Function Get-BuildTools {
     }
 }
 
-Get-BuildTools -BuildBranch $BuildBranch
+if (-not (Test-Path $ServerCommonRoot))
+{
+    New-Item -ItemType directory -Path $ServerCommonRoot
+}
+Set-Location $ServerCommonRoot
+Get-BuildTools -BuildBranchCommit $BuildBranchCommit
 Set-Location $NuGetClientRoot
 Remove-Item -Path $ServerCommonRoot -Recurse -Force
 


### PR DESCRIPTION
This change will help us to maintain a commit hash for specific reference when building a project.

- Since we cannot clone a repository using only a commit id, I'm adding branch name to help us have the flexibility to specify our own if necessary on `$BuildBranch` (default is `main`).
- `$BuildBranchCommit` specifies the exact commit the branch will move to. If no commit is specified, then it will use the latest from the cloned branch.