### PR TITLE
Updated nuget.exe download link to a version with PackageSourceMapping

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -441,7 +441,7 @@ Function Install-NuGet {
 
             Trace-Log 'Downloading nuget.exe'
             Invoke-WebRequest `
-                https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe `
+                https://dist.nuget.org/win-x86-commandline/v6.0.0-preview4/nuget.exe `
                 -UseBasicParsing `
                 -OutFile $NuGetExe
             


### PR DESCRIPTION
Updated the nuget.exe download link in `build/common.ps1` to a version that includes PackageSourceMapping (v6.0.0-preview4), so that the CI/CD pipeline for NuGetGallery now has the updated feature.

Unblocks https://github.com/NuGet/NuGetGallery/pull/8754

*Why?*

The NuGetGallery CI/CD pipeline uses the build scripts from this repo to install nuget.exe, and then uses that exe to restore the NuGetGallery solution. In order for this nuget.exe to pick up the PackageSourceMapping xml elements and process them, it needs to be updated to the latest version. I have updated the download link in the `Install-NuGet` method in `common.ps1` to point to this latest version.