### PR TITLE
.net core 2.2 is out of support, trying to use 3.1

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -531,9 +531,9 @@ Function Install-DotnetCLI {
 
     $installDotnet = Join-Path $CLIRoot "dotnet-install.ps1"
 
-    wget -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/cli/release/2.2.1xx/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
+    wget -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/cli/release/3.1.4xx/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
 
-    & $installDotnet -Channel preview -i $CLIRoot -Version 2.2.100-preview3-009430
+    & $installDotnet -Channel 3.1 -i $CLIRoot -Version latest
 
     if (-not (Test-Path $DotNetExe)) {
         Error-Log "Unable to find dotnet.exe. The CLI install may have failed." -Fatal

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -531,7 +531,7 @@ Function Install-DotnetCLI {
 
     $installDotnet = Join-Path $CLIRoot "dotnet-install.ps1"
 
-    wget -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/cli/release/3.1.4xx/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
+    Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/dotnet/cli/release/3.1.4xx/scripts/obtain/dotnet-install.ps1' -OutFile $installDotnet
 
     & $installDotnet -Channel 3.1 -i $CLIRoot -Version latest
 


### PR DESCRIPTION
Previously used version of .net core installer does not seem to be available anymore (and causes build failures). 3.1 is LTS, so will use that one instead.