### PR TITLE
update markdig version

### DIFF
--- a/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
+++ b/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig.Signed">
-      <Version>0.22.0</Version>
+      <Version>0.26.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>


### PR DESCRIPTION
Upgrade markdig to 0.26.0

Test: 
Functional test + unit test
Also manually tested email publisher, detail page with readme package