### PR TITLE
Update service bus version to update the breaking dependencies

### DIFF
--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -19,7 +19,7 @@
       <Version>10.0.3</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.ServiceBus">
-      <Version>6.0.3</Version>
+      <Version>6.2.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
+++ b/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
@@ -5,9 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.ServiceBus">
-      <Version>6.2.0</Version>
-    </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>
     </PackageReference>

--- a/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
+++ b/tests/NuGet.Services.ServiceBus.Tests/NuGet.Services.ServiceBus.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.ServiceBus">
-      <Version>6.0.3</Version>
+      <Version>6.2.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>


### PR DESCRIPTION
`WindowsAzure.ServiceBus` takes a dependency on the `System.IdentityModel.Tokens.Jwt` which is overridden by another package with a superior version of `Jwt` library which breaks the managed identity authentication due to a breaking change. Updating the service bus to up the underlying dependency.