### PR TITLE
Blob copy routines

### DIFF
--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -102,9 +102,9 @@ namespace NuGet.Services.Storage
             return _primaryStorage.ExistsAsync(fileName, cancellationToken);
         }
 
-        public override Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
+        public override Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken)
         {
-            return _primaryStorage.List(cancellationToken);
+            return _primaryStorage.List(getMetadata, cancellationToken);
         }
     }
 }

--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -44,7 +44,6 @@ namespace NuGet.Services.Storage
             throw new NotImplementedException();
         }
 
-
         protected override Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();

--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -33,7 +33,18 @@ namespace NuGet.Services.Storage
         
             BaseAddress = _primaryStorage.BaseAddress;
         }
-        
+
+        protected override Task OnCopyAsync(
+            Uri sourceUri,
+            IStorage destinationStorage,
+            Uri destinationUri,
+            IReadOnlyDictionary<string, string> destinationProperties,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+
         protected override Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();

--- a/src/NuGet.Services.Storage/AggregateStorage.cs
+++ b/src/NuGet.Services.Storage/AggregateStorage.cs
@@ -106,5 +106,10 @@ namespace NuGet.Services.Storage
         {
             return _primaryStorage.List(getMetadata, cancellationToken);
         }
+
+        public override Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -29,7 +29,6 @@ namespace NuGet.Services.Storage
             bool useServerSideCopy,
             bool initializeContainer,
             ILogger<AzureStorage> logger)
-            
             : this(
                   account.CreateCloudBlobClient().GetContainerReference(containerName).GetDirectoryReference(path),
                   baseAddress,

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -234,7 +234,10 @@ namespace NuGet.Services.Storage
                         operationContext: null,
                         cancellationToken: cancellationToken);
 
-                    _logger.LogInformation("Saved compressed blob {BlobUri} to container {ContainerName}", blob.Uri.ToString(), _directory.Container.Name);
+                    if (Verbose)
+                    {
+                        _logger.LogInformation("Saved compressed blob {BlobUri} to container {ContainerName}", blob.Uri.ToString(), _directory.Container.Name);
+                    }
                 }
             }
             else
@@ -248,7 +251,10 @@ namespace NuGet.Services.Storage
                         operationContext: null,
                         cancellationToken: cancellationToken);
 
-                    _logger.LogInformation("Saved uncompressed blob {BlobUri} to container {ContainerName}", blob.Uri.ToString(), _directory.Container.Name);
+                    if (Verbose)
+                    {
+                        _logger.LogInformation("Saved uncompressed blob {BlobUri} to container {ContainerName}", blob.Uri.ToString(), _directory.Container.Name);
+                    }
                 }
             }
         }

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -118,18 +118,19 @@ namespace NuGet.Services.Storage
             return false;
         }
 
-        public override async Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
+        public override async Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken)
         {
-            var files = await _directory.ListBlobsAsync(cancellationToken);
+            var files = await _directory.ListBlobsAsync(getMetadata, cancellationToken);
 
             return files.Select(GetStorageListItem).AsEnumerable();
         }
 
         private StorageListItem GetStorageListItem(IListBlobItem listBlobItem)
         {
-            var lastModified = (listBlobItem as CloudBlockBlob)?.Properties.LastModified?.UtcDateTime;
+            var cloudBlockBlob = (listBlobItem as CloudBlockBlob);
+            var lastModified = cloudBlockBlob?.Properties.LastModified?.UtcDateTime;
 
-            return new StorageListItem(listBlobItem.Uri, lastModified);
+            return new StorageListItem(listBlobItem.Uri, lastModified, cloudBlockBlob?.Metadata);
         }
 
         protected override async Task OnCopyAsync(

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -125,6 +125,18 @@ namespace NuGet.Services.Storage
             return files.Select(GetStorageListItem).AsEnumerable();
         }
 
+        public override async Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata)
+        {
+            var blob = GetBlockBlobReference(GetName(resourceUri));
+
+            foreach (var kvp in metadata)
+            {
+                blob.Metadata[kvp.Key] = kvp.Value;
+            }
+
+            await blob.SetMetadataAsync();
+        }
+
         private StorageListItem GetStorageListItem(IListBlobItem listBlobItem)
         {
             var cloudBlockBlob = (listBlobItem as CloudBlockBlob);

--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -14,13 +14,25 @@ namespace NuGet.Services.Storage
         string _path;
         private Uri _differentBaseAddress = null;
         private readonly ILogger<AzureStorage> _azureStorageLogger;
+        private readonly bool _useServerSideCopy;
+        private readonly bool _initializeContainer;
 
-        public AzureStorageFactory(CloudStorageAccount account, string containerName, ILogger<AzureStorage> azureStorageLogger, string path = null, Uri baseAddress = null)
+        public AzureStorageFactory(
+            CloudStorageAccount account,
+            string containerName,
+            ILogger<AzureStorage> azureStorageLogger,
+            string path = null,
+            Uri baseAddress = null,
+            bool useServerSideCopy = true,
+            bool initializeContainer = true
+            )
         {
             _account = account;
             _containerName = containerName;
             _path = null;
             _azureStorageLogger = azureStorageLogger;
+            _useServerSideCopy = useServerSideCopy;
+            _initializeContainer = initializeContainer;
 
             if (path != null)
             {
@@ -71,7 +83,7 @@ namespace NuGet.Services.Storage
                 newBase = new Uri(_differentBaseAddress, name + "/");
             }
 
-            return new AzureStorage(_account, _containerName, path, newBase, _azureStorageLogger) { Verbose = Verbose, CompressContent = CompressContent };
+            return new AzureStorage(_account, _containerName, path, newBase, _useServerSideCopy, _initializeContainer, _azureStorageLogger) { Verbose = Verbose, CompressContent = CompressContent };
         }
     }
 }

--- a/src/NuGet.Services.Storage/CloudBlobStorageExtensions.cs
+++ b/src/NuGet.Services.Storage/CloudBlobStorageExtensions.cs
@@ -11,19 +11,21 @@ namespace NuGet.Services.Storage
     internal static class CloudBlobStorageExtensions
     {
         public static async Task<IEnumerable<IListBlobItem>> ListBlobsAsync(
-            this CloudBlobDirectory directory, CancellationToken cancellationToken)
+            this CloudBlobDirectory directory,
+            bool getMetadata,
+            CancellationToken cancellationToken)
         {
             var items = new List<IListBlobItem>();
             BlobContinuationToken continuationToken = null;
             do
             {
                 var segment = await directory.ListBlobsSegmentedAsync(
-                    useFlatBlobListing: true, 
-                    blobListingDetails: BlobListingDetails.None,  
-                    maxResults: null, 
+                    useFlatBlobListing: true,
+                    blobListingDetails: getMetadata ? BlobListingDetails.Metadata : BlobListingDetails.None,
+                    maxResults: null,
                     currentToken:  continuationToken,
-                    options: null, 
-                    operationContext: null, 
+                    options: null,
+                    operationContext: null,
                     cancellationToken: cancellationToken);
 
                 continuationToken = segment.ContinuationToken;

--- a/src/NuGet.Services.Storage/FileStorage.cs
+++ b/src/NuGet.Services.Storage/FileStorage.cs
@@ -57,8 +57,17 @@ namespace NuGet.Services.Storage
             set;
         }
 
-        //  save
+        protected override Task OnCopyAsync(
+            Uri sourceUri,
+            IStorage destinationStorage,
+            Uri destinationUri,
+            IReadOnlyDictionary<string, string> destinationProperties,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
 
+        //  save
         protected override async Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
             SaveCount++;

--- a/src/NuGet.Services.Storage/FileStorage.cs
+++ b/src/NuGet.Services.Storage/FileStorage.cs
@@ -172,5 +172,10 @@ namespace NuGet.Services.Storage
                 await Task.Run(() => { fileInfo.Delete(); },cancellationToken);
             }
         }
+
+        public override Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGet.Services.Storage/FileStorage.cs
+++ b/src/NuGet.Services.Storage/FileStorage.cs
@@ -41,7 +41,7 @@ namespace NuGet.Services.Storage
             return Task.FromResult(Exists(fileName));
         }
 
-        public override Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken)
+        public override Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken)
         {
             DirectoryInfo directoryInfo = new DirectoryInfo(Path);
             var files = directoryInfo.GetFiles("*", SearchOption.AllDirectories)

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -25,5 +25,6 @@ namespace NuGet.Services.Storage
             Uri destinationUri,
             IReadOnlyDictionary<string, string> destinationProperties,
             CancellationToken cancellation);
+        Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata);
     }
 }

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -18,7 +18,7 @@ namespace NuGet.Services.Storage
         Task<string> LoadString(Uri resourceUri, CancellationToken cancellationToken);
         Uri BaseAddress { get; }
         Uri ResolveUri(string relativeUri);
-        Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);
+        Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken);
         Task CopyAsync(
             Uri sourceUri,
             IStorage destinationStorage,

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -19,5 +19,11 @@ namespace NuGet.Services.Storage
         Uri BaseAddress { get; }
         Uri ResolveUri(string relativeUri);
         Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);
+        Task CopyAsync(
+            Uri sourceUri,
+            IStorage destinationStorage,
+            Uri destinationUri,
+            IReadOnlyDictionary<string, string> destinationProperties,
+            CancellationToken cancellation);
     }
 }

--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>2.2.0</Version>
     </PackageReference>

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -154,7 +154,7 @@ namespace NuGet.Services.Storage
         public Uri BaseAddress { get; protected set; }
         public abstract bool Exists(string fileName);
         public abstract Task<bool> ExistsAsync(string fileName, CancellationToken cancellationToken);
-        public abstract Task<IEnumerable<StorageListItem>> List(CancellationToken cancellationToken);
+        public abstract Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken);
 
         public bool Verbose
         {

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -245,5 +245,7 @@ namespace NuGet.Services.Storage
                 ExecutionTimeInMilliseconds = executionTimeInMilliseconds
             });
         }
+
+        public abstract Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata);
     }
 }

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -28,9 +29,40 @@ namespace NuGet.Services.Storage
             return BaseAddress.ToString();
         }
 
+        protected abstract Task OnCopyAsync(
+            Uri sourceUri,
+            IStorage destinationStorage,
+            Uri destinationUri,
+            IReadOnlyDictionary<string, string> destinationProperties,
+            CancellationToken cancellationToken);
         protected abstract Task OnSave(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken);
         protected abstract Task<StorageContent> OnLoad(Uri resourceUri, CancellationToken cancellationToken);
         protected abstract Task OnDelete(Uri resourceUri, CancellationToken cancellationToken);
+
+        public async Task CopyAsync(
+            Uri sourceUri,
+            IStorage destinationStorage,
+            Uri destinationUri,
+            IReadOnlyDictionary<string, string> destinationProperties,
+            CancellationToken cancellationToken)
+        {
+            TraceMethod(nameof(CopyAsync), sourceUri);
+
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                await OnCopyAsync(sourceUri, destinationStorage, destinationUri, destinationProperties, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                TraceException(nameof(CopyAsync), sourceUri, e);
+                throw;
+            }
+
+            TraceExecutionTime(nameof(CopyAsync), sourceUri, stopwatch.ElapsedMilliseconds);
+        }
+
 
         public async Task Save(Uri resourceUri, StorageContent content, bool overwrite, CancellationToken cancellationToken)
         {
@@ -197,6 +229,21 @@ namespace NuGet.Services.Storage
             {
                 _logger.LogInformation("{Method} {ResourceUri}", method, resourceUri);
             }
+        }
+
+        private void TraceException(string method, Uri resourceUri, Exception exception)
+        {
+            _logger.LogError(exception, "{Method} threw exception for {Url}", method, resourceUri);
+        }
+
+        private void TraceExecutionTime(string method, Uri resourceUri, long executionTimeInMilliseconds)
+        {
+            _logger.LogInformation("Execution time: {@data}", new
+            {
+                MethodName = method,
+                StreamUri = GetUri(GetName(resourceUri)),
+                ExecutionTimeInMilliseconds = executionTimeInMilliseconds
+            });
         }
     }
 }

--- a/src/NuGet.Services.Storage/StorageConstants.cs
+++ b/src/NuGet.Services.Storage/StorageConstants.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.Storage
+{
+    public static class StorageConstants
+    {
+        public const string CacheControl = "CacheControl";
+        public const string ContentType = "ContentType";
+    }
+}

--- a/src/NuGet.Services.Storage/StorageListItem.cs
+++ b/src/NuGet.Services.Storage/StorageListItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.Services.Storage
 {
@@ -11,10 +12,13 @@ namespace NuGet.Services.Storage
 
         public DateTime? LastModifiedUtc { get; private set; }
 
-        public StorageListItem(Uri uri, DateTime? lastModifiedUtc)
+        public IDictionary<string, string> Metadata { get; private set; }
+
+        public StorageListItem(Uri uri, DateTime? lastModifiedUtc, IDictionary<string, string> metadata = null)
         {
             Uri = uri;
             LastModifiedUtc = lastModifiedUtc;
+            Metadata = metadata;
         }
     }
 }

--- a/tests/NuGet.Services.Storage.Tests/AzureStorageFacts.cs
+++ b/tests/NuGet.Services.Storage.Tests/AzureStorageFacts.cs
@@ -103,7 +103,9 @@ namespace NuGet.Services.Storage.Tests
                     ContainerName,
                     _dirPath,
                     BaseAddress,
-                    new Mock<ILogger<AzureStorage>>().Object);
+                    useServerSideCopy: true,
+                    initializeContainer: true,
+                    logger: new Mock<ILogger<AzureStorage>>().Object);
 
                 _resourceUri = new Uri(BaseAddress, BlobName);
             }


### PR DESCRIPTION
Porting blob copy routines from https://github.com/NuGet/NuGet.Jobs/blob/main/src/Catalog/Persistence/
Added the ability to request blob metadata when listing blobs and a function to update it.
Moved some particularly noisy logs under `Verbose` flag.