### PR TITLE
Wider applicability of getting blob last modified time.

### DIFF
--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -138,7 +138,7 @@ namespace NuGet.Services.Storage
 
         private StorageListItem GetStorageListItem(IListBlobItem listBlobItem)
         {
-            var cloudBlockBlob = (listBlobItem as CloudBlockBlob);
+            var cloudBlockBlob = (listBlobItem as CloudBlob);
             var lastModified = cloudBlockBlob?.Properties.LastModified?.UtcDateTime;
 
             return new StorageListItem(listBlobItem.Uri, lastModified, cloudBlockBlob?.Metadata);


### PR DESCRIPTION
`Properties` property is actually defined in `CloudBlob` which is a parent of `CloudBlockBlob`. Using a proper superclass allows to support many blob types, not only block blobs.
Fails with append blobs before change, succeeds after.