### PR TITLE
Add net6 target to messaging projects

### DIFF
--- a/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
+++ b/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6</TargetFrameworks>
     <Description>Components shared between the front-end and back-end concerning email messaging</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Markdig.Signed">
-      <Version>0.26.0</Version>
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
+++ b/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6</TargetFrameworks>
     <Description>Logic shared between the front-end and back-end concerning asynchronous messaging</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
First step in addressing: https://github.com/NuGet/Engineering/issues/4434

This reduces the [ATF footprint](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1701) in building `NuGetGallery.Services` `net6` targets. Targeting `net6` in these libraries is generally sufficient to not deploy framework binaries in their nupkgs, however some are still included (e.g. MarkdownMailer) but are not problematic for this targeting work.