### PR TITLE
Excise MarkdownMail from netcore target in NuGet.Services.Messaging.Email

### DIFF
--- a/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
+++ b/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Interfaces used for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
+++ b/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
@@ -1,14 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Components shared between the front-end and back-end concerning email messaging</Description>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <Compile Remove=".\CoreMarkdownMessageService.cs" />
+  </ItemGroup>  
+  
   <ItemGroup>
     <PackageReference Include="Markdig.Signed">
       <Version>0.30.2</Version>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
     </PackageReference>

--- a/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
+++ b/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
@@ -1,18 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Logic shared between the front-end and back-end concerning asynchronous messaging</Description>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <Compile Remove=".\ServiceBusMessageSerializer.cs" />
+  </ItemGroup>
+        
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Extensions.Logging">
       <Version>2.2.0</Version>
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Logging">
+      <Version>7.0.0-preview.5.22301.12</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <ProjectReference Include="..\NuGet.Services.ServiceBus\NuGet.Services.ServiceBus.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Partially addresses: https://github.com/NuGet/Engineering/issues/4434

This transitive dependency on MarkdownMailer was causing errors in CI as it was using attempting [ATF]((https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1701) and failing. We don't need this dependency for this work, and possibly a substitute dependency could be included in a netcore target if mailing with markdown were needed in that context, but this would be separate work.

Note also that a `net6` target is inconsistent with other existing netcore targets in our repos, and I want to bring it back into alignment by retrgeting to `netstandard2.1` which is compatible with `net6`. When we do wish to migrate all of these targets to `net6`, this should be separate work which would include necessary agent pool changes in CI. This could be undertaken in the near future, but it's a cost that may be good to avoid this early in the task above (and its epic)--it's important to put prototyping to bed and move into building.

The `ServiceBus` dependency is also unnecessary for this work, and to rewrite the `WindowsAzure.ServiceBus` pieces as netcore targeted is again a cost that would best be included in work relevant to it.