### PR TITLE
DevSkim warnings addressed.

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -151,8 +151,7 @@ Function Invoke-BuildStep {
         $completed = $false
 
         try {
-            #DevSkim: ignore DS104456. Internal build tool called from our build scripts.
-            Invoke-Command $Expression -ArgumentList $Arguments -ErrorVariable err
+            Invoke-Command $Expression -ArgumentList $Arguments -ErrorVariable err #DevSkim: ignore DS104456. Internal build tool called from our build scripts.
             $completed = $true
         }
         finally {
@@ -907,8 +906,7 @@ Function Install-PrivateBuildTools() {
     $commit = $env:PRIVATE_BUILD_TOOLS_COMMIT
 
     if (-Not $commit) {
-        #DevSkim: ignore DS173237. Not a token/secret. It is a git commit hash.
-        $commit = '4b7460b2e08249e4c65307e5383dfba7fe4da8b7'
+        $commit = '4b7460b2e08249e4c65307e5383dfba7fe4da8b7' #DevSkim: ignore DS173237. Not a token/secret. It is a git commit hash.
     }
 
     if (-Not $repository) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -151,6 +151,7 @@ Function Invoke-BuildStep {
         $completed = $false
 
         try {
+            #DevSkim: ignore DS104456. Internal build tool called from our build scripts.
             Invoke-Command $Expression -ArgumentList $Arguments -ErrorVariable err
             $completed = $true
         }
@@ -906,6 +907,7 @@ Function Install-PrivateBuildTools() {
     $commit = $env:PRIVATE_BUILD_TOOLS_COMMIT
 
     if (-Not $commit) {
+        #DevSkim: ignore DS173237. Not a token/secret. It is a git commit hash.
         $commit = '4b7460b2e08249e4c65307e5383dfba7fe4da8b7'
     }
 

--- a/build/runcodeanalysis.ps1
+++ b/build/runcodeanalysis.ps1
@@ -12,9 +12,6 @@ param (
     [string]$FxCopOutputDirectory
 )
 
-# Enable TLS 1.2 since GitHub requires it.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-
 # To avoid repository dependencies, this script relies on the following assumptions:
 # - parent directory contains a single *.sln
 # - parent directory contains a build.ps1


### PR DESCRIPTION
Suppressed warning about commit hash mistaken for a secret.
Removed PS code enabling TLS 1.2. It seems it is enabled on our build machines by default now.