### PR TITLE
Preferring build environment's dotnet.exe to our own.

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -4,7 +4,14 @@ $DefaultConfiguration = 'debug'
 $NuGetClientRoot = Split-Path -Path $PSScriptRoot -Parent
 $CLIRoot = Join-Path $NuGetClientRoot 'cli'
 $PrivateRoot = Join-Path $PSScriptRoot "private"
-$DotNetExe = Join-Path $CLIRoot 'dotnet.exe'
+$DotNetExeCommand = Get-Command dotnet.exe -ErrorAction Continue
+if ($DotNetExeCommand) {
+    # prefer dotnet.exe present in build environment
+    $DotNetExe = $DotNetExeCommand.Source
+}
+else {
+    $DotNetExe = Join-Path $CLIRoot 'dotnet.exe'
+}
 $NuGetExe = Join-Path $NuGetClientRoot '.nuget\nuget.exe'
 $7zipExe = Join-Path $NuGetClientRoot 'tools\7zip\7za.exe'
 $BuiltInVsWhereExe = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"


### PR DESCRIPTION
We switched to building our projects using MS-hosted agents that have dotnet preinstalled with an assortment of SDKs. There is no need for us download and install one every time we build something, we can reuse existing one just fine.