### PR TITLE
Function for adding new package source mappings to nuget.config files.

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -962,8 +962,7 @@ Function Add-PackageSourceMapping(
     [Parameter(Mandatory=$True)]$SourceKey,
     [Parameter(Mandatory=$True)]$Pattern) {
     if (-not [System.IO.Path]::IsPathRooted($NuGetConfigPath)) {
-        Error-Log "NuGetConfigPath must be absolute"
-        return
+        $NuGetConfigPath = Join-Path $PWD $NuGetConfigPath
     }
 
     $config = [xml](Get-Content -Raw $NuGetConfigPath)


### PR DESCRIPTION
At build time we occasionally need to add private package sources to NuGet.Config. Added function to do that.
The function will create package source if it is absent in the file.