### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -12,6 +12,7 @@ namespace NuGet.Services.Configuration
     {
         private string _vaultName;
         private bool _useManagedIdentity;
+        private string _tenantId;
         private string _clientId;
         private string _certificateThumbprint;
         private string _storeName;
@@ -34,6 +35,7 @@ namespace NuGet.Services.Configuration
                 _useManagedIdentity = bool.Parse(useManagedIdentity);
             }
 
+            _tenantId = config[Constants.KeyVaultTenanIdKey];
             _clientId = config[Constants.KeyVaultClientIdKey];
             _certificateThumbprint = config[Constants.KeyVaultCertificateThumbprintKey];
             if (_useManagedIdentity && IsCertificateConfigurationProvided())
@@ -83,7 +85,8 @@ namespace NuGet.Services.Configuration
                     _validateCertificate);
 
                 keyVaultConfiguration = new KeyVaultConfiguration(
-                    _vaultName,                
+                    _vaultName,
+                    _tenantId,
                     _clientId,
                     certificate,
                     _sendX5c);
@@ -100,7 +103,8 @@ namespace NuGet.Services.Configuration
         private bool IsCertificateConfigurationProvided()
         {
             return !string.IsNullOrEmpty(_clientId)
-                || !string.IsNullOrEmpty(_certificateThumbprint);
+                || !string.IsNullOrEmpty(_certificateThumbprint)
+                || !string.IsNullOrEmpty(_tenantId);
         }
     }
 }

--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -70,7 +70,7 @@ namespace NuGet.Services.Configuration
 
             if (_useManagedIdentity)
             {
-                keyVaultConfiguration = new KeyVaultConfiguration(_vaultName);
+                keyVaultConfiguration = new KeyVaultConfiguration(_vaultName, _clientId);
             }
             else
             {

--- a/src/NuGet.Services.Configuration/Constants.cs
+++ b/src/NuGet.Services.Configuration/Constants.cs
@@ -7,6 +7,7 @@ namespace NuGet.Services.Configuration
     {
         public static string KeyVaultVaultNameKey = "KeyVault_VaultName";
         public static string KeyVaultUseManagedIdentity = "KeyVault_UseManagedIdentity";
+        public static string KeyVaultTenanIdKey = "KeyVault_TenantId";
         public static string KeyVaultClientIdKey = "KeyVault_ClientId";
         public static string KeyVaultCertificateThumbprintKey = "KeyVault_CertificateThumbprint";
         public static string KeyVaultValidateCertificateKey = "KeyVault_ValidateCertificate";

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -10,6 +10,7 @@ namespace NuGet.Services.KeyVault
     {
         public string VaultName { get; }
         public bool UseManagedIdentity { get; }
+        public string TenantId { get; }
         public string ClientId { get; }
         public X509Certificate2 Certificate { get; }
         public bool SendX5c { get; }
@@ -32,10 +33,11 @@ namespace NuGet.Services.KeyVault
         /// The constructor for keyvault configuration when using the certificate
         /// </summary>
         /// <param name="vaultName">The name of the keyvault</param>
+        /// <param name="tenantId">AAD tenant ID where respective client app is registered.</param>
         /// <param name="clientId">Keyvault client id</param>
         /// <param name="certificate">Certificate required to access the keyvault</param>
         /// <param name="sendX5c">SendX5c property</param>
-        public KeyVaultConfiguration(string vaultName, string clientId, X509Certificate2 certificate, bool sendX5c = false)
+        public KeyVaultConfiguration(string vaultName, string tenantId, string clientId, X509Certificate2 certificate, bool sendX5c = false)
         {
             if (string.IsNullOrWhiteSpace(vaultName))
             {
@@ -48,6 +50,7 @@ namespace NuGet.Services.KeyVault
             }
 
             UseManagedIdentity = false;
+            TenantId = tenantId;
             VaultName = vaultName;
             ClientId = clientId;
             Certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -18,7 +18,7 @@ namespace NuGet.Services.KeyVault
         /// <summary>
         /// The constructor for keyvault configuration when using managed identities
         /// </summary>
-        public KeyVaultConfiguration(string vaultName)
+        public KeyVaultConfiguration(string vaultName, string clientId = null)
         {
             if (string.IsNullOrWhiteSpace(vaultName))
             {
@@ -27,6 +27,7 @@ namespace NuGet.Services.KeyVault
 
             VaultName = vaultName;
             UseManagedIdentity = true;
+            ClientId = clientId;
         }
 
         /// <summary>

--- a/src/NuGet.Services.KeyVault/KeyVaultConfigurationExtensions.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfigurationExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    public static class KeyVaultConfigurationExtensions
+    {
+        public static Uri GetKeyVaultUri(this KeyVaultConfiguration self)
+        {
+            var uriString = $"https://{self.VaultName}.vault.azure.net/";
+            return new Uri(uriString);
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -61,7 +61,10 @@ namespace NuGet.Services.KeyVault
             TokenCredential credential = null;
             if (_configuration.UseManagedIdentity)
             {
-                credential = new DefaultAzureCredential();
+                credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+                {
+                    ManagedIdentityClientId = _configuration.ClientId
+                });
             }
             else
             {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -19,8 +19,7 @@ namespace NuGet.Services.KeyVault
         private readonly KeyVaultConfiguration _configuration;
         private readonly Lazy<SecretClient> _keyVaultClient;
 
-        protected string VaultBaseUrl => _vault;
-        protected KeyVaultClient KeyVaultClient => _keyVaultClient.Value;
+        protected SecretClient KeyVaultClient => _keyVaultClient.Value;
 
         public KeyVaultReader(KeyVaultConfiguration configuration)
         {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.KeyVault
             TokenCredential credential = null;
             if (_configuration.UseManagedIdentity)
             {
-                credential = new ManagedIdentityCredential();
+                credential = new ManagedIdentityCredential(_configuration.ClientId);
             }
             else
             {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -59,12 +59,17 @@ namespace NuGet.Services.KeyVault
         private SecretClient InitializeClient()
         {
             TokenCredential credential = null;
+
             if (_configuration.UseManagedIdentity)
             {
-                credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+                if (string.IsNullOrEmpty(_configuration.ClientId))
                 {
-                    ManagedIdentityClientId = _configuration.ClientId
-                });
+                    credential = new DefaultAzureCredential();
+                }
+                else
+                {
+                    credential = new ManagedIdentityCredential(_configuration.ClientId);
+                }
             }
             else
             {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -61,7 +61,7 @@ namespace NuGet.Services.KeyVault
             TokenCredential credential = null;
             if (_configuration.UseManagedIdentity)
             {
-                credential = new ManagedIdentityCredential(_configuration.ClientId);
+                credential = new DefaultAzureCredential();
             }
             else
             {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -62,7 +62,7 @@ namespace NuGet.Services.KeyVault
             TokenCredential credential = null;
             if (_configuration.UseManagedIdentity)
             {
-                credential = new DefaultAzureCredential();
+                credential = new ManagedIdentityCredential();
             }
             else
             {

--- a/src/NuGet.Services.KeyVault/KeyVaultWriter.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultWriter.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.KeyVault.Models;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 
 namespace NuGet.Services.KeyVault
 {
@@ -19,16 +20,10 @@ namespace NuGet.Services.KeyVault
             string secretValue,
             DateTimeOffset? expiration = null)
         {
-            SecretAttributes attributes = null;
-            if (expiration.HasValue)
-            {
-                attributes = new SecretAttributes
-                {
-                    Expires = expiration.Value.UtcDateTime,
-                };
-            }
+            var secret = new Azure.Security.KeyVault.Secrets.KeyVaultSecret(secretName, secretValue);
+            secret.Properties.ExpiresOn = expiration;
 
-            await KeyVaultClient.SetSecretAsync(VaultBaseUrl, secretName, secretValue, secretAttributes: attributes);
+            await KeyVaultClient.SetSecretAsync(secret);
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault">
-      <Version>3.0.5</Version>
-    </PackageReference>
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication">
       <Version>1.4.0</Version>
     </PackageReference>

--- a/tools/AzureSqlConnectionTest/TestApplication.cs
+++ b/tools/AzureSqlConnectionTest/TestApplication.cs
@@ -18,6 +18,8 @@ namespace AzureSqlConnectionTest
 
         public CommandOption KeyVaultName { get; }
 
+        public CommandOption KeyVaultTenantId { get; }
+
         public CommandOption KeyVaultClientId { get; }
 
         public CommandOption KeyVaultCertificateThumbprint { get; }
@@ -41,6 +43,7 @@ namespace AzureSqlConnectionTest
             Help = HelpOption("-? | -h | --help");
 
             KeyVaultName = Option("-kv | --keyVaultName", "KeyVault name", CommandOptionType.SingleValue);
+            KeyVaultTenantId = Option("-kvtid | --keyVaultTenantId", "KeyVault tenant id", CommandOptionType.SingleValue);
             KeyVaultClientId = Option("-kvcid | --keyVaultClientId", "KeyVault client id", CommandOptionType.SingleValue);
             KeyVaultCertificateThumbprint = Option("-kvct | --keyVaultCertThumbprint", "KeyVault certificate thumbprint", CommandOptionType.SingleValue);
 
@@ -81,6 +84,7 @@ namespace AzureSqlConnectionTest
                     {
                         var keyVaultConfig = new KeyVaultConfiguration(
                             KeyVaultName.Value(),
+                            KeyVaultTenantId.Value(),
                             KeyVaultClientId.Value(),
                             kvCertificate);
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/4704

Transition from `Microsoft.Azure.KeyVault` to `Azure.Security.KeyVault` package dependency. Former one is deprecated.
I manually tested this change in [Gallery dev environment](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1478870) 