### PR TITLE
Update azure identity to 1.10.4

### DIFF
--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />


### PR DESCRIPTION
Update azure identity to 1.10.4

PMP has dependency on ServerCommon, update this package. 

Address: https://devdiv.visualstudio.com/OnlineServices/_git/PackageManagement-Platform/pullrequest/526886