### PR TITLE
`GetRawBody` method

### DIFF
--- a/src/NuGet.Services.Contracts/ServiceBus/IReceivedBrokeredMessage.cs
+++ b/src/NuGet.Services.Contracts/ServiceBus/IReceivedBrokeredMessage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.ServiceBus
@@ -20,5 +21,6 @@ namespace NuGet.Services.ServiceBus
         Task AbandonAsync();
         string GetBody();
         TStream GetBody<TStream>();
+        Stream GetRawBody();
     }
 }

--- a/src/NuGet.Services.ServiceBus/ServiceBusReceivedMessageWrapper.cs
+++ b/src/NuGet.Services.ServiceBus/ServiceBusReceivedMessageWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -46,6 +47,11 @@ namespace NuGet.Services.ServiceBus
         public TStream GetBody<TStream>()
         {
             return ServiceBusClientHelper.DeserializeXmlDataContract<TStream>(ServiceBusReceivedMessage.Body);
+        }
+
+        public Stream GetRawBody()
+        {
+            return ServiceBusReceivedMessage.Body.ToStream();
         }
 
         public Task CompleteAsync()


### PR DESCRIPTION
One of the monitoring jobs requires access to raw message body data to properly deserialize the message. Calling `BrokeredMessage.GetBody<Stream>` worked with the previous version of the Service Bus library. Migrating to new version broke that (as there is no direct equivalent and our reimplementation disregarded that case). Adding explicit method to support that scenario.

Another potential solution here is to update `GetBody<TStream>` implementation to check if `TStream` is `System.IO.Stream` and do something else, but I'm not sure what else it might break. Creating new method is safer.