### PR TITLE
Use latest C# version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,10 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">

--- a/src/NuGet.Services.Build/NuGet.Services.Build.csproj
+++ b/src/NuGet.Services.Build/NuGet.Services.Build.csproj
@@ -7,7 +7,7 @@
     <!--
     We force C# 5 because the FindDuplicateFiles task is compiled using CodeTaskFactory, which only supports this C# version.
     -->
-    <LangVersion>5</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Services.Build/NuGet.Services.Build.csproj
+++ b/src/NuGet.Services.Build/NuGet.Services.Build.csproj
@@ -3,11 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Description>Shared component to assist NuGet build scripts.</Description>
-
-    <!--
-    We force C# 5 because the FindDuplicateFiles task is compiled using CodeTaskFactory, which only supports this C# version.
-    -->
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
@@ -21,6 +21,11 @@ namespace NuGet.Services
             Assert.NotEmpty(types);
             foreach (var type in types)
             {
+                if (type.FullName.StartsWith("Microsoft.") || type.FullName.StartsWith("System."))
+                {
+                    continue;
+                }
+
                 Assert.True(type.IsEnum || type.IsInterface, $"{type.FullName} must either be an interface or an enum.");
             }
         }


### PR DESCRIPTION
Partially address: https://github.com/NuGet/Engineering/issues/5525
We could move to latest C# version like 12 which [is same as client team](https://github.com/NuGet/NuGet.Client/blob/5f1401c2de4e7d75f8c58bbb45d9df828f2de2d1/build/common.project.props#L98).
![image](https://github.com/user-attachments/assets/e49d2a01-bc09-4c29-8ae8-11df99b46bd0)

It's [blocking NuGet.Jobs release](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9869300&view=logs&j=8515a029-22a6-5510-9e17-f5665af94c87&t=6006c852-547b-5c40-1e5c-b5a098dddd13&l=589)