### PR TITLE
Fix typo in common.ps1

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -872,7 +872,7 @@ Function Set-VersionInfo {
     }
 
     # make sure the directory exists
-    $directory = Split-Path $_
+    $directory = Split-Path $Path
     New-Item -ItemType Directory -Force -Path $directory | Out-Null
         
     Trace-Log "Setting assembly info in ""$Path"""


### PR DESCRIPTION
This works because the call sites normally have `$_` set.

Bug introduced by https://github.com/NuGet/ServerCommon/pull/434.