### PR TITLE
Align package versions, remove unused method, quality "common" build steps

### DIFF
--- a/.pipelines/ServerCommon-CI.yml
+++ b/.pipelines/ServerCommon-CI.yml
@@ -84,3 +84,4 @@ extends:
           inputs:
             testRunner: VSTest
             testResultsFiles: $(ServerCommonPath)\Results.*.xml
+            failTaskOnFailedTests: true

--- a/.pipelines/ServerCommon-CI.yml
+++ b/.pipelines/ServerCommon-CI.yml
@@ -77,10 +77,10 @@ extends:
             scriptName: $(ServerCommonPath)\test.ps1
             arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId)
             workingFolder: $(ServerCommonPath)
-        - task: PublishTestResults@1
+        - task: PublishTestResults@2
           name: PublishTestResults_3
           displayName: Publish Test Results Results.*.xml
           condition: succeededOrFailed()
           inputs:
-            testRunner: XUnit
+            testRunner: VSTest
             testResultsFiles: $(ServerCommonPath)\Results.*.xml

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageVersion Include="Azure.Storage.DataMovement.Blobs" Version="12.0.0-beta.4" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.18.0" />
-    <PackageVersion Include="EntityFramework" Version="6.4.0-preview3-19553-01" />
-    <PackageVersion Include="FluentAssertions" Version="5.4.2" />
+    <PackageVersion Include="EntityFramework" Version="6.4.4" />
+    <PackageVersion Include="FluentAssertions" Version="5.5.0" />
     <PackageVersion Include="Markdig.Signed" Version="0.30.2" />
     <PackageVersion Include="MicroBuild.Core" Version="0.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -24,16 +24,12 @@
       <package pattern="NuGet.*" />
       <package pattern="Owin" />
       <package pattern="runtime.*" />
+      <package pattern="Serilog.*" />
       <package pattern="Serilog" />
-      <package pattern="Serilog.Enrichers.Environment" />
-      <package pattern="Serilog.Enrichers.Process" />
-      <package pattern="Serilog.Extensions.Logging" />
-      <package pattern="Serilog.Sinks.ApplicationInsights" />
-      <package pattern="Serilog.Sinks.Console" />
       <package pattern="SerilogTraceListener" />
       <package pattern="System.*" />
-      <package pattern="xunit" />
       <package pattern="xunit.*" />
+      <package pattern="xunit" />
     </packageSource>
     <packageSource key="nuget-build">
       <package pattern="NuGet.StrongName.*" />

--- a/build.ps1
+++ b/build.ps1
@@ -40,19 +40,7 @@ Invoke-BuildStep 'Getting private build tools' { Install-PrivateBuildTools } `
 Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet } `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Clearing package cache' { Clear-PackageCache } `
-    -skip:(-not $CleanCache) `
-    -ev +BuildErrors
-
 Invoke-BuildStep 'Clearing artifacts' { Clear-Artifacts } `
-    -ev +BuildErrors
-
-Invoke-BuildStep 'Setting common version metadata in AssemblyInfo.cs' {
-        $CommonProjects | Where-Object { !$_.IsTest } | ForEach-Object {
-            $Path = Join-Path $_.Directory "Properties\AssemblyInfo.g.cs"
-            Set-VersionInfo $Path -AssemblyVersion $CommonAssemblyVersion -PackageVersion $CommonPackageVersion -Branch $Branch -Commit $CommitSHA
-        }
-    } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Restoring solution packages' {
@@ -61,6 +49,14 @@ Invoke-BuildStep 'Restoring solution packages' {
         Install-SolutionPackages -path $SolutionPath -output $PackagesDir -ExcludeVersion
     } `
     -skip:$SkipRestore `
+    -ev +BuildErrors
+
+Invoke-BuildStep 'Setting common version metadata in AssemblyInfo.cs' {
+        $CommonProjects | Where-Object { !$_.IsTest } | ForEach-Object {
+            $Path = Join-Path $_.Directory "Properties\AssemblyInfo.g.cs"
+            Set-VersionInfo $Path -AssemblyVersion $CommonAssemblyVersion -PackageVersion $CommonPackageVersion -Branch $Branch -Commit $CommitSHA
+        }
+    } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Building common solution' {

--- a/build.ps1
+++ b/build.ps1
@@ -55,7 +55,7 @@ Invoke-BuildStep 'Setting common version metadata in AssemblyInfo.cs' {
     } `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Restoring solution packages' { `
+Invoke-BuildStep 'Restoring solution packages' {
         $SolutionPath = Join-Path $PSScriptRoot "packages.config"
         $PackagesDir = Join-Path $PSScriptRoot "packages"
         Install-SolutionPackages -path $SolutionPath -output $PackagesDir -ExcludeVersion
@@ -63,9 +63,8 @@ Invoke-BuildStep 'Restoring solution packages' { `
     -skip:$SkipRestore `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Building common solution' { `
-        $SolutionPath = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
-        Build-Solution -Configuration $Configuration -BuildNumber $BuildNumber -SolutionPath $SolutionPath -SkipRestore:$SkipRestore
+Invoke-BuildStep 'Building common solution' {
+        Build-Solution -Configuration $Configuration -BuildNumber $BuildNumber -SolutionPath $CommonSolution -SkipRestore:$SkipRestore
     } `
     -ev +BuildErrors
 
@@ -74,30 +73,10 @@ Invoke-BuildStep 'Signing the binaries' {
     } `
     -ev +BuildErrors
     
-Invoke-BuildStep 'Creating common artifacts' { `
-        $CommonProjects =
-            "src\NuGet.Services.Build\NuGet.Services.Build.csproj",
-            "src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj",
-            "src\NuGet.Services.Contracts\NuGet.Services.Contracts.csproj",
-            "src\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj",
-            "src\NuGet.Services.FeatureFlags\NuGet.Services.FeatureFlags.csproj",
-            "src\NuGet.Services.Incidents\NuGet.Services.Incidents.csproj",
-            "src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj",
-            "src\NuGet.Services.Licenses\NuGet.Services.Licenses.csproj",
-            "src\NuGet.Services.Logging\NuGet.Services.Logging.csproj",
-            "src\NuGet.Services.Messaging.Email\NuGet.Services.Messaging.Email.csproj",
-            "src\NuGet.Services.Messaging\NuGet.Services.Messaging.csproj",
-            "src\NuGet.Services.Owin\NuGet.Services.Owin.csproj",
-            "src\NuGet.Services.ServiceBus\NuGet.Services.ServiceBus.csproj",
-            "src\NuGet.Services.Sql\NuGet.Services.Sql.csproj",
-            "src\NuGet.Services.Status.Table\NuGet.Services.Status.Table.csproj",
-            "src\NuGet.Services.Status\NuGet.Services.Status.csproj",
-            "src\NuGet.Services.Storage\NuGet.Services.Storage.csproj",
-            "src\NuGet.Services.Testing.Entities\NuGet.Services.Testing.Entities.csproj",
-            "src\NuGet.Services.Validation.Issues\NuGet.Services.Validation.Issues.csproj",
-            "src\NuGet.Services.Validation\NuGet.Services.Validation.csproj"
-        $CommonProjects | ForEach-Object {
-            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $CommonPackageVersion
+Invoke-BuildStep 'Creating common artifacts' {
+        $CommonPackages = $CommonProjects | Where-Object { !$_.IsTest } | Where-Object { $_.RelativePath -notlike "tools*" } 
+        $CommonPackages | ForEach-Object {
+            New-ProjectPackage $_.Path -Configuration $Configuration -BuildNumber $BuildNumber -Version $CommonPackageVersion
         }
     } `
     -ev +BuildErrors

--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,6 @@ param (
     [string]$Configuration = 'debug',
     [int]$BuildNumber,
     [switch]$SkipRestore,
-    [switch]$CleanCache,
     [string]$CommonAssemblyVersion = '3.0.0',
     [string]$CommonPackageVersion = '3.0.0-zlocal',
     [string]$Branch,

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -500,16 +500,6 @@ Function Format-BuildNumber([int]$BuildNumber) {
     '{0:D4}' -f $BuildNumber
 }
 
-Function Clear-PackageCache {
-    [CmdletBinding()]
-    param()
-    Trace-Log 'Clearing package cache'
-
-    & $NuGetExe locals http-cache -clear -verbosity detailed
-    #& nuget locals global-packages -clear -verbosity detailed
-    & $NuGetExe locals temp -clear -verbosity detailed
-}
-
 Function Install-SolutionPackages {
     [CmdletBinding()]
     param(

--- a/test.ps1
+++ b/test.ps1
@@ -29,7 +29,7 @@ $CommonSolution = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
 $CommonProjects = Get-SolutionProjects $CommonSolution
     
 Invoke-BuildStep 'Cleaning test results' { Clear-Tests } `
-    -ev +BuildErrors
+    -ev +TestErrors
 
 Invoke-BuildStep 'Running tests' {
         $CommonTestProjects = $CommonProjects | Where-Object { $_.IsTest }

--- a/test.ps1
+++ b/test.ps1
@@ -27,17 +27,17 @@ Trace-Log "Build #$BuildNumber started at $startTime"
 $TestErrors = @()
 $CommonSolution = Join-Path $PSScriptRoot "NuGet.Server.Common.sln"
 $CommonProjects = Get-SolutionProjects $CommonSolution
-    
+
 Invoke-BuildStep 'Cleaning test results' { Clear-Tests } `
     -ev +TestErrors
 
-Invoke-BuildStep 'Running tests' {
+Invoke-BuildStep 'Running common tests' {
         $CommonTestProjects = $CommonProjects | Where-Object { $_.IsTest }
 
         $TestCount = 0
         
         $CommonTestProjects | ForEach-Object {
-            $TestResultFile = Join-Path $PSScriptRoot "Results.$TestCount.xml"
+            $TestResultFile = Join-Path $PSScriptRoot "Results.Common.$TestCount.xml"
             Trace-Log "Testing $($_.Path)"
             dotnet test $_.Path --no-restore --no-build --configuration $Configuration "-l:trx;LogFileName=$TestResultFile"
             if (-not (Test-Path $TestResultFile)) {

--- a/tests/NuGet.Services.Logging.Tests/App.config
+++ b/tests/NuGet.Services.Logging.Tests/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-  </startup>
-</configuration>

--- a/tools/AzureSqlConnectionTest/App.config
+++ b/tools/AzureSqlConnectionTest/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-    </startup>
-</configuration>


### PR DESCRIPTION
This is further clean up to ease a repository merge. 

Summary of changes:
- Switch publish test results to `VSTest` since `dotnet test` is used.
- Align package versions with NuGetGallery and NuGet.Jobs
- Simplify package source mapping to match NuGetGallery and NuGet.Jobs
- Remove build.ps1 `-CleanCache`. It's not used anywhere and is weak due to only clearing `temp` and `http-cache`
- Remove useless `app.config` files