### PR TITLE
Add global MSI client id for KV

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -33,10 +33,14 @@ namespace NuGet.Services.Configuration
             if (!string.IsNullOrEmpty(useManagedIdentity))
             {
                 _useManagedIdentity = bool.Parse(useManagedIdentity);
+                _clientId = string.IsNullOrEmpty(config[Constants.KeyVaultClientIdKey]) ? config[Constants.ManagedIdentityClientIdKey] : config[Constants.KeyVaultClientIdKey];
+            }
+            else
+            {
+                _clientId = config[Constants.KeyVaultClientIdKey];
             }
 
             _tenantId = config[Constants.KeyVaultTenantIdKey];
-            _clientId = config[Constants.KeyVaultClientIdKey];
             _certificateThumbprint = config[Constants.KeyVaultCertificateThumbprintKey];
             if (_useManagedIdentity && IsCertificateConfigurationProvided())
             {
@@ -45,7 +49,7 @@ namespace NuGet.Services.Configuration
 
             _storeName = config[Constants.KeyVaultStoreNameKey];
             _storeLocation = config[Constants.KeyVaultStoreLocationKey];
-            
+
             string validateCertificate = config[Constants.KeyVaultValidateCertificateKey];
             if (!string.IsNullOrEmpty(validateCertificate))
             {

--- a/src/NuGet.Services.Configuration/Constants.cs
+++ b/src/NuGet.Services.Configuration/Constants.cs
@@ -7,6 +7,7 @@ namespace NuGet.Services.Configuration
     {
         public static string KeyVaultVaultNameKey = "KeyVault_VaultName";
         public static string KeyVaultUseManagedIdentity = "KeyVault_UseManagedIdentity";
+        public static string ManagedIdentityClientIdKey = "ManagedIdentityClientId";
         public static string KeyVaultTenantIdKey = "KeyVault_TenantId";
         public static string KeyVaultClientIdKey = "KeyVault_ClientId";
         public static string KeyVaultCertificateThumbprintKey = "KeyVault_CertificateThumbprint";

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -42,7 +42,7 @@ namespace NuGet.Services.KeyVault
         /// </summary>
         /// <param name="vaultName">The name of the keyvault</param>
         /// <param name="tenantId">AAD tenant ID where respective client app is registered.</param>
-        /// <param name="clientId">Keyvault client id</param>
+        /// <param name="clientId">Keyvault client id used for certificate authentication or managed identity client id.</param>
         /// <param name="certificate">Certificate required to access the keyvault</param>
         /// <param name="sendX5c">SendX5c property</param>
         public KeyVaultConfiguration(string vaultName, string tenantId, string clientId, X509Certificate2 certificate, bool sendX5c = false)


### PR DESCRIPTION
# Changes
* Added "ManagedIdentityClientId" configuration, so that we can add only one MSI on config files for all services in a job, KV/Storage/etc.
* KeyVault configuration now uses "KeyVault_ClientId" if specified or fallbacks to "ManagedIdentityClientId".