### PR TITLE
Change Azure Storage copy to use server side copy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageVersion Include="Azure.Storage.DataMovement.Blobs" Version="12.0.0-beta.4" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageVersion Include="EntityFramework" Version="6.4.4" />
     <PackageVersion Include="FluentAssertions" Version="5.5.0" />

--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Azure.Storage.Blobs;
-using Azure.Storage.DataMovement.Blobs;
 using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.Storage
@@ -11,31 +10,33 @@ namespace NuGet.Services.Storage
     public class AzureStorageFactory : StorageFactory
     {
         BlobServiceClient _account;
-        BlobsStorageResourceProvider _storageResourceProvider;
         string _containerName;
         string _path;
         private Uri _differentBaseAddress = null;
         private readonly ILogger<AzureStorage> _azureStorageLogger;
-        private readonly bool _useServerSideCopy;
         private readonly bool _initializeContainer;
+
+        public static string PrepareConnectionString(string connectionString)
+        {
+            // workaround for https://github.com/Azure/azure-sdk-for-net/issues/44373
+            connectionString = connectionString.Replace("SharedAccessSignature=?", "SharedAccessSignature=");
+
+            return connectionString;
+        }
 
         public AzureStorageFactory(
             BlobServiceClient account,
-            BlobsStorageResourceProvider blobsStorageResourceProvider,
             string containerName,
             ILogger<AzureStorage> azureStorageLogger,
             string path = null,
             Uri baseAddress = null,
-            bool useServerSideCopy = true,
             bool initializeContainer = true
             )
         {
             _account = account;
-            _storageResourceProvider = blobsStorageResourceProvider;
             _containerName = containerName;
             _path = null;
             _azureStorageLogger = azureStorageLogger;
-            _useServerSideCopy = useServerSideCopy;
             _initializeContainer = initializeContainer;
 
             if (path != null)
@@ -87,7 +88,7 @@ namespace NuGet.Services.Storage
                 newBase = new Uri(_differentBaseAddress, name + "/");
             }
 
-            return new AzureStorage(_account, _storageResourceProvider, _containerName, path, newBase, _useServerSideCopy, _initializeContainer, _azureStorageLogger) { Verbose = Verbose, CompressContent = CompressContent };
+            return new AzureStorage(_account, _containerName, path, newBase, _initializeContainer, _azureStorageLogger) { Verbose = Verbose, CompressContent = CompressContent };
         }
     }
 }

--- a/src/NuGet.Services.Storage/IStorage.cs
+++ b/src/NuGet.Services.Storage/IStorage.cs
@@ -19,6 +19,7 @@ namespace NuGet.Services.Storage
         Uri BaseAddress { get; }
         Uri ResolveUri(string relativeUri);
         IEnumerable<StorageListItem> List(bool getMetadata);
+        Task<IEnumerable<StorageListItem>> ListAsync(bool getMetadata, CancellationToken cancellationToken);
         Task CopyAsync(
             Uri sourceUri,
             IStorage destinationStorage,

--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Azure.Storage.DataMovement.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
+++ b/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.DataMovement.Blobs;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
@@ -21,7 +20,6 @@ namespace NuGet.Services.Storage.Tests
         private Mock<BlockBlobClient> _blobClientMock = new Mock<BlockBlobClient>();
         private Mock<BlobServiceClient> _blobServiceClientMock = new Mock<BlobServiceClient>();
         private Mock<BlobContainerClient> _blobContainerClientMock = new Mock<BlobContainerClient>();
-        private Mock<BlobsStorageResourceProvider> _blobStorageResourceProviderMock = new Mock<BlobsStorageResourceProvider>();
         private Mock<ILogger<AzureStorage>> _loggerMock = new Mock<ILogger<AzureStorage>>();
 
         public AzureStorageNewFacts() 
@@ -37,7 +35,7 @@ namespace NuGet.Services.Storage.Tests
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore",ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
             _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, _blobStorageResourceProviderMock.Object, "containerName", "path", new Uri("http://baseAddress"), useServerSideCopy: true, initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
 
             Assert.Equal(azureStorage.Exists("file"), expected);
         }
@@ -52,7 +50,7 @@ namespace NuGet.Services.Storage.Tests
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
             _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, _blobStorageResourceProviderMock.Object, "containerName", "path", new Uri("http://baseAddress"), useServerSideCopy: true, initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
 
             Assert.Equal(await azureStorage.ExistsAsync("file", CancellationToken.None), expected);
         }
@@ -78,7 +76,7 @@ namespace NuGet.Services.Storage.Tests
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
             _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, _blobStorageResourceProviderMock.Object, "containerName", "path", new Uri("http://baseAddress"), useServerSideCopy: true, initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
 
             await azureStorage.Save(new Uri("http://testUri.com/blob.json"), new StringStorageContent("content"), overwrite: overwrite, CancellationToken.None);
 


### PR DESCRIPTION
The only place that uses this method is here:
https://github.com/NuGet/NuGetGallery/blob/99b2b4961bc4d62e9bab60993390b08260be639a/src/Stats.PostProcessReports/DetailedReportPostProcessor.cs#L208

This uses server-side copy already. So the extra dependency on `DataMovement` is not needed.

This PR essentially copies the copy implementation from the original copy of this copied project, still existing here:
https://github.com/NuGet/NuGetGallery/blob/99b2b4961bc4d62e9bab60993390b08260be639a/src/Catalog/Persistence/AzureStorage.cs#L221-L274

Also add a helper method to replicate this:
https://github.com/NuGet/NuGetGallery/blob/2e4a1498efac7feb99ce49a71b0bf13863448fad/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs#L45-L46