### PR TITLE
Fix Partition Key and Row Key assignments in Status entities

### DIFF
--- a/src/NuGet.Services.Status.Table/ChildEntity.cs
+++ b/src/NuGet.Services.Status.Table/ChildEntity.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Azure;
 using Azure.Data.Tables;
-using System;
 
 namespace NuGet.Services.Status.Table
 {
@@ -13,13 +13,17 @@ namespace NuGet.Services.Status.Table
     public class ChildEntity<TParent> : ITableEntity, IChildEntity<TParent>
         where TParent : ITableEntity
     {
-        public ChildEntity() { }
+        public ChildEntity()
+        {
+        }
 
         public ChildEntity(
             string partitionKey,
             string rowKey,
             string parentRowKey)
         {
+            PartitionKey = partitionKey;
+            RowKey = rowKey;
             ParentRowKey = parentRowKey;
         }
 
@@ -47,6 +51,6 @@ namespace NuGet.Services.Status.Table
         {
             get { return !string.IsNullOrEmpty(ParentRowKey); }
             set { }
-        }   
+        }
     }
 }

--- a/src/NuGet.Services.Status.Table/ComponentAffectingEntity.cs
+++ b/src/NuGet.Services.Status.Table/ComponentAffectingEntity.cs
@@ -12,11 +12,8 @@ namespace NuGet.Services.Status.Table
     /// </summary>
     public class ComponentAffectingEntity : ITableEntity, IComponentAffectingEntity
     {
-        private ITableEntity _tableEntity;
-
         public ComponentAffectingEntity()
         {
-            _tableEntity = new TableEntity();
         }
 
         public ComponentAffectingEntity(
@@ -31,7 +28,8 @@ namespace NuGet.Services.Status.Table
             AffectedComponentStatus = (int)affectedComponentStatus;
             StartTime = startTime;
             EndTime = endTime;
-            _tableEntity = new TableEntity(partitionKey, rowKey);
+            PartitionKey = partitionKey;
+            RowKey = rowKey;
         }
 
         public string AffectedComponentPath { get; set; }
@@ -58,9 +56,9 @@ namespace NuGet.Services.Status.Table
             set { }
         }
 
-        public string PartitionKey { get => _tableEntity.PartitionKey; set => _tableEntity.PartitionKey = value; }
-        public string RowKey { get => _tableEntity.RowKey; set => _tableEntity.RowKey = value; }
-        public DateTimeOffset? Timestamp { get => _tableEntity.Timestamp; set => _tableEntity.Timestamp = value; }
-        public ETag ETag { get => _tableEntity.ETag; set => _tableEntity.ETag = value; }
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
     }
 }

--- a/src/NuGet.Services.Status.Table/CursorEntity.cs
+++ b/src/NuGet.Services.Status.Table/CursorEntity.cs
@@ -11,26 +11,24 @@ namespace NuGet.Services.Status.Table
     {
         public const string DefaultPartitionKey = "cursors";
 
-        private ITableEntity _tableEntity;
-
         public CursorEntity()
         {
-            _tableEntity = new TableEntity();
         }
 
         public CursorEntity(string name, DateTime value)
         {
             Value = value;
-            _tableEntity = new TableEntity(DefaultPartitionKey, GetRowKey(name));
+            PartitionKey = DefaultPartitionKey;
+            RowKey = GetRowKey(name);
         }
 
         public string Name => RowKey;
 
         public DateTime Value { get; set; }
-        public string PartitionKey { get => _tableEntity.PartitionKey; set => _tableEntity.PartitionKey = value; }
-        public string RowKey { get => _tableEntity.RowKey; set => _tableEntity.RowKey = value; }
-        public DateTimeOffset? Timestamp { get => _tableEntity.Timestamp; set => _tableEntity.Timestamp = value; }
-        public ETag ETag { get => _tableEntity.ETag; set => _tableEntity.ETag = value; }
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
 
         public static string GetRowKey(string name)
         {

--- a/src/NuGet.Services.Status.Table/Manual/ManualStatusChangeEntity.cs
+++ b/src/NuGet.Services.Status.Table/Manual/ManualStatusChangeEntity.cs
@@ -11,18 +11,16 @@ namespace NuGet.Services.Status.Table.Manual
     {
         public const string DefaultPartitionKey = "manual";
 
-        private ITableEntity _tableEntity;
-
         public ManualStatusChangeEntity()
         {
-            _tableEntity = new TableEntity();
         }
 
         protected ManualStatusChangeEntity(
             ManualStatusChangeType type)
         {
             Type = (int)type;
-            _tableEntity = new TableEntity(DefaultPartitionKey, GetRowKey(Guid.NewGuid()));
+            PartitionKey = DefaultPartitionKey;
+            RowKey = GetRowKey(Guid.NewGuid());
         }
 
         public Guid Guid => Guid.Parse(RowKey);
@@ -32,10 +30,10 @@ namespace NuGet.Services.Status.Table.Manual
         /// See https://github.com/Azure/azure-storage-net/issues/383
         /// </remarks>
         public int Type { get; set; }
-        public string PartitionKey { get => _tableEntity.PartitionKey; set => _tableEntity.PartitionKey = value; }
-        public string RowKey { get => _tableEntity.RowKey; set => _tableEntity.RowKey = value; }
-        public DateTimeOffset? Timestamp { get => _tableEntity.Timestamp; set => _tableEntity.Timestamp = value; }
-        public ETag ETag { get => _tableEntity.ETag; set => _tableEntity.ETag = value; }
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
 
         public static string GetRowKey(Guid guid)
         {


### PR DESCRIPTION
Currently, `ChildEntity` does not set PK and RK. This causes `StatusAggregator` tests in NuGetGallery to fail.

This supports a repository merge effort.

Also, remove internal `TableEntity` field in other entities since it adds no value. It takes this PR comment all the way:
https://github.com/NuGet/ServerCommon/pull/430#discussion_r1671439519