### PR TITLE
Force AzureStorageFactory to specify blob public access

### DIFF
--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -11,6 +11,7 @@ namespace NuGet.Services.Storage
     {
         BlobServiceClient _account;
         string _containerName;
+        private readonly bool _enablePublicAccess;
         string _path;
         private Uri _differentBaseAddress = null;
         private readonly ILogger<AzureStorage> _azureStorageLogger;
@@ -27,14 +28,15 @@ namespace NuGet.Services.Storage
         public AzureStorageFactory(
             BlobServiceClient account,
             string containerName,
+            bool enablePublicAccess,
             ILogger<AzureStorage> azureStorageLogger,
             string path = null,
             Uri baseAddress = null,
-            bool initializeContainer = true
-            )
+            bool initializeContainer = true)
         {
             _account = account;
             _containerName = containerName;
+            _enablePublicAccess = enablePublicAccess;
             _path = null;
             _azureStorageLogger = azureStorageLogger;
             _initializeContainer = initializeContainer;
@@ -88,7 +90,18 @@ namespace NuGet.Services.Storage
                 newBase = new Uri(_differentBaseAddress, name + "/");
             }
 
-            return new AzureStorage(_account, _containerName, path, newBase, _initializeContainer, _azureStorageLogger) { Verbose = Verbose, CompressContent = CompressContent };
+            return new AzureStorage(
+                _account,
+                _containerName,
+                path,
+                newBase,
+                _initializeContainer,
+                _enablePublicAccess,
+                _azureStorageLogger)
+            {
+                Verbose = Verbose,
+                CompressContent = CompressContent,
+            };
         }
     }
 }

--- a/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
+++ b/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -23,19 +25,154 @@ namespace NuGet.Services.Storage.Tests
         private Mock<ILogger<AzureStorage>> _loggerMock = new Mock<ILogger<AzureStorage>>();
 
         public AzureStorageNewFacts() 
-        {   }
+        {
+            _blobContainerClientMock
+                .Setup(x => x.GetProperties(
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Mock.Of<Response<BlobContainerProperties>>());
+            _blobServiceClientMock
+                .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
+                .Returns(_blobContainerClientMock.Object);
+        }
+
+        [Fact]
+        public void Constructor_DoNotInitialize()
+        {
+            var azureStorage = new AzureStorage(
+                _blobServiceClientMock.Object,
+                "containerName",
+                "path",
+                new Uri("http://baseAddress"),
+                initializeContainer: false,
+                enablePublicAccess: false,
+                _loggerMock.Object);
+
+            _blobContainerClientMock.Verify(x => x.GetProperties(
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+            _blobContainerClientMock.Verify(x => x.CreateIfNotExists(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<BlobContainerEncryptionScopeOptions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+            _blobContainerClientMock.Verify(x => x.SetAccessPolicy(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IEnumerable<BlobSignedIdentifier>>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(true, PublicAccessType.Blob)]
+        [InlineData(false, PublicAccessType.None)]
+        public void Constructor_Initialize_ContainerDoesNotExist(bool enablePublicAccess, PublicAccessType publicAccess)
+        {
+            var getPropertiesSetup = _blobContainerClientMock
+                .Setup(x => x.GetProperties(
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new RequestFailedException(404, "Not found"));
+
+            var azureStorage = new AzureStorage(
+                _blobServiceClientMock.Object,
+                "containerName",
+                "path",
+                new Uri("http://baseAddress"),
+                initializeContainer: true,
+                enablePublicAccess,
+                _loggerMock.Object);
+
+            _blobContainerClientMock.Verify(x => x.CreateIfNotExists(
+                publicAccess,
+                default,
+                default,
+                default), Times.Once);
+            _blobContainerClientMock.Verify(x => x.SetAccessPolicy(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IEnumerable<BlobSignedIdentifier>>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(true, PublicAccessType.Blob)]
+        [InlineData(false, PublicAccessType.None)]
+        public void Constructor_Initialize_ContainerExists_AccessMatches(bool enablePublicAccess, PublicAccessType publicAccess)
+        {
+            var getPropertiesSetup = _blobContainerClientMock
+                .Setup(x => x.GetProperties(
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Response.FromValue(
+                    BlobsModelFactory.BlobContainerProperties(default, default, publicAccess: publicAccess),
+                    Mock.Of<Response>()));
+
+            var azureStorage = new AzureStorage(
+                _blobServiceClientMock.Object,
+                "containerName",
+                "path",
+                new Uri("http://baseAddress"),
+                initializeContainer: true,
+                enablePublicAccess,
+                _loggerMock.Object);
+
+            _blobContainerClientMock.Verify(x => x.CreateIfNotExists(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<BlobContainerEncryptionScopeOptions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+            _blobContainerClientMock.Verify(x => x.SetAccessPolicy(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IEnumerable<BlobSignedIdentifier>>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(true, PublicAccessType.Blob)]
+        [InlineData(false, PublicAccessType.None)]
+        public void Constructor_Initialize_ContainerExists_AccessDoesNotMatch(bool enablePublicAccess, PublicAccessType publicAccess)
+        {
+            var getPropertiesSetup = _blobContainerClientMock
+                .Setup(x => x.GetProperties(
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Response.FromValue(
+                    BlobsModelFactory.BlobContainerProperties(default, default, publicAccess: ~publicAccess),
+                    Mock.Of<Response>()));
+
+            var azureStorage = new AzureStorage(
+                _blobServiceClientMock.Object,
+                "containerName",
+                "path",
+                new Uri("http://baseAddress"),
+                initializeContainer: true,
+                enablePublicAccess,
+                _loggerMock.Object);
+
+            _blobContainerClientMock.Verify(x => x.CreateIfNotExists(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<BlobContainerEncryptionScopeOptions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+            _blobContainerClientMock.Verify(x => x.SetAccessPolicy(
+                publicAccess,
+                default,
+                default,
+                default), Times.Once);
+        }
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void Exists(bool expected)
         {
-            var azureResponse = new Mock<Azure.Response>();
-            _blobClientMock.Setup(c => c.Exists(It.IsAny<CancellationToken>())).Returns(Azure.Response.FromValue(expected, azureResponse.Object));
+            var azureResponse = new Mock<Response>();
+            _blobClientMock.Setup(c => c.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(expected, azureResponse.Object));
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore",ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             Assert.Equal(azureStorage.Exists("file"), expected);
         }
@@ -45,12 +182,11 @@ namespace NuGet.Services.Storage.Tests
         [InlineData(false)]
         public async Task ExistsAsync(bool expected)
         {
-            var azureResponse = new Mock<Azure.Response>();
-            _blobClientMock.Setup(c => c.ExistsAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(Azure.Response.FromValue(expected, azureResponse.Object)));
+            var azureResponse = new Mock<Response>();
+            _blobClientMock.Setup(c => c.ExistsAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(Response.FromValue(expected, azureResponse.Object)));
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             Assert.Equal(await azureStorage.ExistsAsync("file", CancellationToken.None), expected);
         }
@@ -62,21 +198,20 @@ namespace NuGet.Services.Storage.Tests
         [InlineData(false, false, 1)]
         public async Task Save(bool overwrite, bool exists, int calledTimes)
         {
-            var azureResponse = new Mock<Azure.Response>();
+            var azureResponse = new Mock<Response>();
             var blobInfoMock = new Mock<BlobInfo>();
             var blobContentInfoMock = new Mock<BlobContentInfo>();
 
             _blobClientMock.Setup(c => c.SetHttpHeadersAsync(It.IsAny<BlobHttpHeaders>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(Azure.Response.FromValue(blobInfoMock.Object, azureResponse.Object)));
+                .Returns(Task.FromResult(Response.FromValue(blobInfoMock.Object, azureResponse.Object)));
             _blobClientMock.Setup(c => c.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(Azure.Response.FromValue(blobContentInfoMock.Object, azureResponse.Object)));
+                .Returns(Task.FromResult(Response.FromValue(blobContentInfoMock.Object, azureResponse.Object)));
             _blobClientMock.Setup(c => c.ExistsAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(Azure.Response.FromValue(exists, azureResponse.Object)));
+                .Returns(Task.FromResult(Response.FromValue(exists, azureResponse.Object)));
 
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            _blobServiceClientMock.Setup(bsc => bsc.GetBlobContainerClient(It.IsAny<string>())).Returns(_blobContainerClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             await azureStorage.Save(new Uri("http://testUri.com/blob.json"), new StringStorageContent("content"), overwrite: overwrite, CancellationToken.None);
 


### PR DESCRIPTION
Before moving to the new Azure SDK, `AzureStorage` was tolerant of existing containers having a different public access level:
https://github.com/NuGet/ServerCommon/blob/f6781f41bb6ec921b8fe81cc05882fe0af7897f6/src/NuGet.Services.Storage/AzureStorage.cs#L53-L55

Because of this, the actual public blob access level on some containers (such as the one used for the Gallery.CredentialExpiration job) have drifted from Blob public access (i.e. becoming no public access). Because of the previous implementation, this was allowsed. `CreateIfNotExists` would return false because the container already existed and updating the public access level would not happen. With the current implementation based on the new SDK, the code tries to update the public access level every time. This fails when the storage account has public access disabled, causing related jobs to fail during startup.
https://github.com/NuGet/ServerCommon/blob/2ccce56c06eebf0759863ca2d68beaf18ebb3916/src/NuGet.Services.Storage/AzureStorage.cs#L51

The fix is to allow the caller to specify what public access level they really need. In the case of the Gallery.CredentialExpiration job, this will be set to `enablePublicAccess: false`.

This is a breaking change in the constructor but I believe it is better to be explicit about whether a container should be public or not.

List of jobs that use this:
- Gallery.CredentialExpiration, `enablePublicAccess: false`
- GitHubVulnerabilities2V3, `enablePublicAccess: true`
- GitHubVulnerabilities2Db, `enablePublicAccess: true`
- Stats.PostProcessReports
  - source storage, `enablePublicAccess: false`
  - work storage, `enablePublicAccess: false`
  - destination storage, `enablePublicAccess: true`
- Validation.PackageSigning.ProcessSignature, `enablePublicAccess: false`
- Validation.PackageSigning.ValidateCertificate, `enablePublicAccess: false`